### PR TITLE
Add error wrapping in the obj package

### DIFF
--- a/formats/obj/mat_reader.go
+++ b/formats/obj/mat_reader.go
@@ -12,10 +12,9 @@ import (
 	"github.com/EliCDavis/polyform/modeling"
 )
 
-func parseFloatLine(components []string) (float64, error) {
-	f, err := strconv.ParseFloat(strings.TrimSpace(components[1]), 32)
-	if err != nil {
-		return 0, fmt.Errorf("unable to parse component %s: %w", components[0], err)
+func parseFloatLine(components []string) (f float64, err error) {
+	if f, err = strconv.ParseFloat(strings.TrimSpace(components[1]), 32); err != nil {
+		return 0, fmt.Errorf("unable to parse component[0] %q: %w", components[0], err)
 	}
 	return f, nil
 }
@@ -25,7 +24,7 @@ func parseColorLine(components []string) (color.Color, error) {
 	g, err := strconv.ParseFloat(strings.TrimSpace(components[2]), 32)
 	b, err := strconv.ParseFloat(strings.TrimSpace(components[3]), 32)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse component %s: %w", components[0], err)
+		return nil, fmt.Errorf("unable to parse component %q: %w", components[0], err)
 	}
 	return color.RGBA{uint8(r * 255), uint8(g * 255), uint8(b * 255), 255}, nil
 }
@@ -77,7 +76,7 @@ func ReadMaterials(in io.Reader) ([]modeling.Material, error) {
 
 			f, err := parseFloatLine(components)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse float line: %w", err)
 			}
 
 			workingMaterial.SpecularHighlight = f
@@ -89,7 +88,7 @@ func ReadMaterials(in io.Reader) ([]modeling.Material, error) {
 
 			f, err := parseColorLine(components)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to parse color line: %w", err)
 			}
 
 			workingMaterial.DiffuseColor = f

--- a/formats/obj/reader.go
+++ b/formats/obj/reader.go
@@ -83,7 +83,10 @@ func parseObjFaceComponent(component string) (v int, vt int, vn int, err error) 
 	if !strings.Contains(component, "/") {
 		v, err = strconv.Atoi(component)
 		v -= 1
-		return v, vt, vn, fmt.Errorf("failed to convert component %q to int: %w", component, err)
+		if err != nil {
+			return v, vt, vn, fmt.Errorf("failed to convert component %q to int: %w", component, err)
+		}
+		return v, vt, vn, nil
 	}
 
 	if strings.Contains(component, "//") {

--- a/formats/obj/reader.go
+++ b/formats/obj/reader.go
@@ -83,7 +83,7 @@ func parseObjFaceComponent(component string) (v int, vt int, vn int, err error) 
 	if !strings.Contains(component, "/") {
 		v, err = strconv.Atoi(component)
 		v -= 1
-		return v, vt, vn, fmt.Errorf("failed to convert component to int: %w", err)
+		return v, vt, vn, fmt.Errorf("failed to convert component %q to int: %w", component, err)
 	}
 
 	if strings.Contains(component, "//") {
@@ -93,6 +93,7 @@ func parseObjFaceComponent(component string) (v int, vt int, vn int, err error) 
 		if err != nil {
 			return v, vt, vn, fmt.Errorf("failed to convert //component[0] %q to int: %w", components[0], err)
 		}
+
 		vn, err = strconv.Atoi(components[1])
 		vn -= 1
 		if err != nil {

--- a/formats/obj/reader_test.go
+++ b/formats/obj/reader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/EliCDavis/vector/vector2"
 	"github.com/EliCDavis/vector/vector3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ReadOBJ_NoTexture(t *testing.T) {
@@ -148,10 +149,10 @@ f  2 3 4
 
 	// ACT ====================================================================
 	contents, matReferences, err := obj.ReadMesh(strings.NewReader(objString))
+	require.NoError(t, err)
 	square := contents[0].Mesh
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
 	assert.Equal(t, 2, square.PrimitiveCount())
 	assert.Len(t, matReferences, 0)
 	assert.Equal(t, "", contents[0].Name)

--- a/formats/obj/writer.go
+++ b/formats/obj/writer.go
@@ -15,76 +15,67 @@ func ColorString(color color.Color) string {
 	return fmt.Sprintf("%f %f %f", float64(r)/0xffff, float64(g)/0xffff, float64(b)/0xffff)
 }
 
-func WriteMaterial(mat modeling.Material, out io.Writer) error {
-	_, err := fmt.Fprintf(out, "newmtl %s\n", strings.Replace(mat.Name, " ", "", -1))
-	if err != nil {
-		return err
+func WriteMaterial(mat modeling.Material, out io.Writer) (err error) {
+	if _, err = fmt.Fprintf(out, "newmtl %s\n", strings.Replace(mat.Name, " ", "", -1)); err != nil {
+		return fmt.Errorf("failed to write newmtl: %w", err)
 	}
 
 	if mat.DiffuseColor != nil {
-		_, err = fmt.Fprintf(out, "Kd %s\n", ColorString(mat.DiffuseColor))
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "Kd %s\n", ColorString(mat.DiffuseColor)); err != nil {
+			return fmt.Errorf("failed to write Kd: %w", err)
 		}
 	}
 
 	if mat.AmbientColor != nil {
-		_, err = fmt.Fprintf(out, "Ka %s\n", ColorString(mat.AmbientColor))
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "Ka %s\n", ColorString(mat.AmbientColor)); err != nil {
+			return fmt.Errorf("failed to write Ka: %w", err)
 		}
 	}
 
 	if mat.SpecularColor != nil {
-		_, err = fmt.Fprintf(out, "Ks %s\n", ColorString(mat.SpecularColor))
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "Ks %s\n", ColorString(mat.SpecularColor)); err != nil {
+			return fmt.Errorf("failed to write Ks: %w", err)
 		}
 	}
 
-	_, err = fmt.Fprintf(out, "Ns %f\n", mat.SpecularHighlight)
-	if err != nil {
-		return err
+	if _, err = fmt.Fprintf(out, "Ns %f\n", mat.SpecularHighlight); err != nil {
+		return fmt.Errorf("failed to write Ns: %w", err)
 	}
 
-	_, err = fmt.Fprintf(out, "Ni %f\n", mat.OpticalDensity)
-	if err != nil {
-		return err
+	if _, err = fmt.Fprintf(out, "Ni %f\n", mat.OpticalDensity); err != nil {
+		return fmt.Errorf("failed to write Ni: %w", err)
 	}
 
-	_, err = fmt.Fprintf(out, "d %f\n", 1-mat.Transparency)
-	if err != nil {
-		return err
+	if _, err = fmt.Fprintf(out, "d %f\n", 1-mat.Transparency); err != nil {
+		return fmt.Errorf("failed to write d: %w", err)
 	}
 
 	if mat.ColorTextureURI != nil {
-		_, err = fmt.Fprintf(out, "map_Kd %s\n", *mat.ColorTextureURI)
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "map_Kd %s\n", *mat.ColorTextureURI); err != nil {
+			return fmt.Errorf("failed to write map_Kd: %w", err)
 		}
 	}
 
 	if mat.NormalTextureURI != nil {
-		_, err = fmt.Fprintf(out, "map_Bump %s\n", *mat.NormalTextureURI)
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "map_Bump %s\n", *mat.NormalTextureURI); err != nil {
+			return fmt.Errorf("failed to write map_Bump: %w", err)
 		}
 
-		_, err = fmt.Fprintf(out, "norm %s\n", *mat.NormalTextureURI)
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "norm %s\n", *mat.NormalTextureURI); err != nil {
+			return fmt.Errorf("failed to write norm: %w", err)
 		}
 	}
 
 	if mat.SpecularTextureURI != nil {
-		_, err = fmt.Fprintf(out, "map_Ks %s\n", *mat.SpecularTextureURI)
-		if err != nil {
-			return err
+		if _, err = fmt.Fprintf(out, "map_Ks %s\n", *mat.SpecularTextureURI); err != nil {
+			return fmt.Errorf("failed to write map_Ks: %w", err)
 		}
 	}
 
-	_, err = fmt.Fprintln(out, "")
-	return err
+	if _, err = fmt.Fprintln(out, ""); err != nil {
+		return fmt.Errorf("failed to write out: %w", err)
+	}
+	return nil
 }
 
 func WriteMaterials(m modeling.Mesh, out io.Writer) error {
@@ -95,25 +86,21 @@ func WriteMaterials(m modeling.Mesh, out io.Writer) error {
 	written := make(map[*modeling.Material]bool)
 
 	for _, mat := range m.Materials() {
-
 		if mat.Material == nil {
 			if !defaultWritten {
-				err := WriteMaterial(modeling.DefaultMaterial(), out)
-				if err != nil {
-					return err
+				if err := WriteMaterial(modeling.DefaultMaterial(), out); err != nil {
+					return fmt.Errorf("failed to write default material: %w", err)
 				}
 				defaultWritten = true
 			}
 			continue
 		}
 
-		_, ok := written[mat.Material]
-		if ok {
+		if _, ok := written[mat.Material]; ok {
 			continue
 		}
-		err := WriteMaterial(*mat.Material, out)
-		if err != nil {
-			return err
+		if err := WriteMaterial(*mat.Material, out); err != nil {
+			return fmt.Errorf("failed to write material %s: %w", mat.Material.Name, err)
 		}
 		written[mat.Material] = true
 	}
@@ -122,9 +109,9 @@ func WriteMaterials(m modeling.Mesh, out io.Writer) error {
 
 func writeUsingMaterial(mat *modeling.Material, out io.Writer) {
 	if mat == nil {
-		fmt.Fprint(out, "usemtl DefaultDiffuse\n")
+		_, _ = fmt.Fprint(out, "usemtl DefaultDiffuse\n")
 	} else {
-		fmt.Fprintf(out, "usemtl %s\n", strings.Replace(mat.Name, " ", "", -1))
+		_, _ = fmt.Fprintf(out, "usemtl %s\n", strings.Replace(mat.Name, " ", "", -1))
 	}
 }
 
@@ -133,9 +120,9 @@ func writeFaceVerts(tris *iter.ArrayIterator[int], out io.Writer, start, end, of
 		p1 := tris.At(triIndex) + 1 + offset
 		p2 := tris.At(triIndex+1) + 1 + offset
 		p3 := tris.At(triIndex+2) + 1 + offset
-		_, err := fmt.Fprintf(out, "f %d %d %d\n", p1, p2, p3)
-		if err != nil {
-			return err
+
+		if _, err := fmt.Fprintf(out, "f %d %d %d\n", p1, p2, p3); err != nil {
+			return fmt.Errorf("failed to write face verts: %w", err)
 		}
 	}
 	return nil
@@ -146,9 +133,8 @@ func writeFaceVertsAndUvs(tris *iter.ArrayIterator[int], out io.Writer, start, e
 		p1 := tris.At(triIndex) + 1 + offset
 		p2 := tris.At(triIndex+1) + 1 + offset
 		p3 := tris.At(triIndex+2) + 1 + offset
-		_, err := fmt.Fprintf(out, "f %d/%d %d/%d %d/%d\n", p1, p1, p2, p2, p3, p3)
-		if err != nil {
-			return err
+		if _, err := fmt.Fprintf(out, "f %d/%d %d/%d %d/%d\n", p1, p1, p2, p2, p3, p3); err != nil {
+			return fmt.Errorf("failed to write face verts and UVs: %w", err)
 		}
 	}
 	return nil
@@ -159,9 +145,8 @@ func writeFaceVertsAndNormals(tris *iter.ArrayIterator[int], out io.Writer, star
 		p1 := tris.At(triIndex) + 1 + offset
 		p2 := tris.At(triIndex+1) + 1 + offset
 		p3 := tris.At(triIndex+2) + 1 + offset
-		_, err := fmt.Fprintf(out, "f %d//%d %d//%d %d//%d\n", p1, p1, p2, p2, p3, p3)
-		if err != nil {
-			return err
+		if _, err := fmt.Fprintf(out, "f %d//%d %d//%d %d//%d\n", p1, p1, p2, p2, p3, p3); err != nil {
+			return fmt.Errorf("failed to write face verts and normals: %w", err)
 		}
 	}
 	return nil
@@ -174,7 +159,7 @@ func writeFaceVertAndUvsAndNormals(tris *iter.ArrayIterator[int], out io.Writer,
 		p3 := tris.At(triIndex+2) + 1 + offset
 		_, err := fmt.Fprintf(out, "f %d/%d/%d %d/%d/%d %d/%d/%d\n", p1, p1, p1, p2, p2, p2, p3, p3, p3)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to write face verts, UVs and normals: %w", err)
 		}
 	}
 	return nil
@@ -185,9 +170,14 @@ func WriteMesh(m modeling.Mesh, materialFile string, out io.Writer) error {
 }
 
 func WriteMeshes(meshes []ObjMesh, materialFile string, out io.Writer) error {
-	fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform")
+	if _, err := fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform"); err != nil {
+		return fmt.Errorf("failed to write attribution comment: %w", err)
+	}
+
 	if materialFile != "" {
-		fmt.Fprintf(out, "mtllib %s\no mesh\n", materialFile)
+		if _, err := fmt.Fprintf(out, "mtllib %s\no mesh\n", materialFile); err != nil {
+			return fmt.Errorf("failed to write matfile 'mesh': %w", err)
+		}
 	}
 
 	for _, objMesh := range meshes {
@@ -196,9 +186,8 @@ func WriteMeshes(meshes []ObjMesh, materialFile string, out io.Writer) error {
 			posData := m.Float3Attribute(modeling.PositionAttribute)
 			for i := 0; i < posData.Len(); i++ {
 				v := posData.At(i)
-				_, err := fmt.Fprintf(out, "v %f %f %f\n", v.X(), v.Y(), v.Z())
-				if err != nil {
-					return err
+				if _, err := fmt.Fprintf(out, "v %f %f %f\n", v.X(), v.Y(), v.Z()); err != nil {
+					return fmt.Errorf("failed to write position attr: %w", err)
 				}
 			}
 		}
@@ -207,9 +196,8 @@ func WriteMeshes(meshes []ObjMesh, materialFile string, out io.Writer) error {
 			uvData := m.Float2Attribute(modeling.TexCoordAttribute)
 			for i := 0; i < uvData.Len(); i++ {
 				uv := uvData.At(i)
-				_, err := fmt.Fprintf(out, "vt %f %f\n", uv.X(), uv.Y())
-				if err != nil {
-					return err
+				if _, err := fmt.Fprintf(out, "vt %f %f\n", uv.X(), uv.Y()); err != nil {
+					return fmt.Errorf("failed to write UV attr: %w", err)
 				}
 			}
 		}
@@ -218,9 +206,8 @@ func WriteMeshes(meshes []ObjMesh, materialFile string, out io.Writer) error {
 			normalData := m.Float3Attribute(modeling.NormalAttribute)
 			for i := 0; i < normalData.Len(); i++ {
 				n := normalData.At(i)
-				_, err := fmt.Fprintf(out, "vn %f %f %f\n", n.X(), n.Y(), n.Z())
-				if err != nil {
-					return err
+				if _, err := fmt.Fprintf(out, "vn %f %f %f\n", n.X(), n.Y(), n.Z()); err != nil {
+					return fmt.Errorf("failed to write UV normal attr: %w", err)
 				}
 			}
 		}
@@ -248,9 +235,8 @@ func WriteMeshes(meshes []ObjMesh, materialFile string, out io.Writer) error {
 		mats := m.Materials()
 		indices := m.Indices()
 		if len(mats) == 0 {
-			err := faceWriter(indices, out, 0, indices.Len(), indexOffset)
-			if err != nil {
-				return err
+			if err := faceWriter(indices, out, 0, indices.Len(), indexOffset); err != nil {
+				return fmt.Errorf("failed to call faceWriter: %w", err)
 			}
 		} else {
 			offset := 0


### PR DESCRIPTION
Add error wrapping throughout the `obj` package, to help debugging. 

I came across an oddly formed .obj file, a product of conversion from STL by some online converter, and it is failing to parse. Debugging that turned out to be very difficult without wrapping as it was just `strconv.Atoi: parsing "": invalid syntax` message with no details of what, where or why. This PR fixes that. 