### PR TITLE
Add SaveAll method for OBJ files

### DIFF
--- a/examples/terrain/main.go
+++ b/examples/terrain/main.go
@@ -138,5 +138,5 @@ func main() {
 	defer mtlFile.Close()
 
 	obj.WriteMesh(terrain, "terrain.mtl", objFile)
-	obj.WriteMaterials(terrain, mtlFile)
+	obj.WriteMaterialsFromMesh(terrain, mtlFile)
 }

--- a/examples/ufo/main.go
+++ b/examples/ufo/main.go
@@ -171,5 +171,5 @@ func main() {
 	defer objFile.Close()
 
 	obj.WriteMesh(final, "ufo.mtl", objFile)
-	obj.WriteMaterials(final, mtlFile)
+	obj.WriteMaterialsFromMesh(final, mtlFile)
 }

--- a/formats/obj/fs.go
+++ b/formats/obj/fs.go
@@ -53,7 +53,7 @@ func Load(objPath string) ([]ObjMesh, error) {
 }
 
 // Save writes the mesh to the path specified in OBJ format, optionally writing
-// an additional MTL file with materials are found within the modeling.
+// an additional MTL file with all materials that are found within the modeling.
 func Save(objPath string, meshToSave modeling.Mesh) error {
 	if err := os.MkdirAll(path.Dir(objPath), os.ModeDir); err != nil {
 		return fmt.Errorf("failed to create all dirs for path %q: %w", objPath, err)
@@ -94,7 +94,7 @@ func Save(objPath string, meshToSave modeling.Mesh) error {
 }
 
 // SaveAll writes all provided meshes to the path specified in OBJ format, optionally writing
-// an additional MTL file with materials are found within the modeling.
+// an additional MTL file with all materials that are found across all meshes.
 func SaveAll(objPath string, meshesToSave map[string]modeling.Mesh) error {
 	if err := os.MkdirAll(path.Dir(objPath), os.ModeDir); err != nil {
 		return fmt.Errorf("failed to create all dirs for path %q: %w", objPath, err)

--- a/formats/obj/fs.go
+++ b/formats/obj/fs.go
@@ -75,7 +75,7 @@ func Save(objPath string, meshToSave modeling.Mesh) error {
 		}
 		defer mtlFile.Close()
 
-		if err = WriteMaterials(meshToSave, mtlFile); err != nil {
+		if err = WriteMaterialsFromMesh(meshToSave, mtlFile); err != nil {
 			return fmt.Errorf("failed to write materials: %w", err)
 		}
 		mtlPath = path.Base(mtlName)
@@ -83,6 +83,57 @@ func Save(objPath string, meshToSave modeling.Mesh) error {
 
 	out := bufio.NewWriter(objFile)
 	if err = WriteMesh(meshToSave, mtlPath, out); err != nil {
+		return fmt.Errorf("failed to write mesh: %w", err)
+	}
+
+	if err = out.Flush(); err != nil {
+		return fmt.Errorf("failed to flush buffer: %w", err)
+	}
+
+	return nil
+}
+
+// SaveAll writes all provided meshes to the path specified in OBJ format, optionally writing
+// an additional MTL file with materials are found within the modeling.
+func SaveAll(objPath string, meshesToSave map[string]modeling.Mesh) error {
+	if err := os.MkdirAll(path.Dir(objPath), os.ModeDir); err != nil {
+		return fmt.Errorf("failed to create all dirs for path %q: %w", objPath, err)
+	}
+
+	objFile, err := os.Create(objPath)
+	if err != nil {
+		return fmt.Errorf("failed to create object file %q: %w", objPath, err)
+	}
+	defer objFile.Close()
+
+	extension := filepath.Ext(objPath)
+	var materials []modeling.MeshMaterial
+	var objMeshes []ObjMesh
+	for name, mesh := range meshesToSave {
+		materials = append(materials, mesh.Materials()...)
+		objMeshes = append(objMeshes, ObjMesh{
+			Name: name, Mesh: mesh,
+		})
+	}
+
+	mtlPath := ""
+	if len(materials) > 0 {
+		mtlName := objPath[0:len(objPath)-len(extension)] + ".mtl"
+		mtlFile, err := os.Create(mtlName)
+		if err != nil {
+			return fmt.Errorf("failed to create material file %q: %w", mtlName, err)
+		}
+		defer mtlFile.Close()
+
+		if err = WriteMaterials(materials, mtlFile); err != nil {
+			return fmt.Errorf("failed to write materials: %w", err)
+		}
+		mtlPath = path.Base(mtlName)
+	}
+
+	out := bufio.NewWriter(objFile)
+
+	if err = WriteMeshes(objMeshes, mtlPath, out); err != nil {
 		return fmt.Errorf("failed to write mesh: %w", err)
 	}
 

--- a/formats/obj/writer.go
+++ b/formats/obj/writer.go
@@ -78,7 +78,7 @@ func WriteMaterial(mat modeling.Material, out io.Writer) (err error) {
 	return nil
 }
 
-func WriteMaterials(m modeling.Mesh, out io.Writer) error {
+func WriteMaterialsFromMesh(m modeling.Mesh, out io.Writer) error {
 	fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform")
 
 	defaultWritten := false
@@ -86,6 +86,35 @@ func WriteMaterials(m modeling.Mesh, out io.Writer) error {
 	written := make(map[*modeling.Material]bool)
 
 	for _, mat := range m.Materials() {
+		if mat.Material == nil {
+			if !defaultWritten {
+				if err := WriteMaterial(modeling.DefaultMaterial(), out); err != nil {
+					return fmt.Errorf("failed to write default material: %w", err)
+				}
+				defaultWritten = true
+			}
+			continue
+		}
+
+		if _, ok := written[mat.Material]; ok {
+			continue
+		}
+		if err := WriteMaterial(*mat.Material, out); err != nil {
+			return fmt.Errorf("failed to write material %s: %w", mat.Material.Name, err)
+		}
+		written[mat.Material] = true
+	}
+	return nil
+}
+
+func WriteMaterials(ms []modeling.MeshMaterial, out io.Writer) error {
+	fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform")
+
+	defaultWritten := false
+
+	written := make(map[*modeling.Material]bool)
+
+	for _, mat := range ms {
 		if mat.Material == nil {
 			if !defaultWritten {
 				if err := WriteMaterial(modeling.DefaultMaterial(), out); err != nil {

--- a/formats/obj/writer.go
+++ b/formats/obj/writer.go
@@ -79,36 +79,11 @@ func WriteMaterial(mat modeling.Material, out io.Writer) (err error) {
 }
 
 func WriteMaterialsFromMesh(m modeling.Mesh, out io.Writer) error {
-	fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform")
-
-	defaultWritten := false
-
-	written := make(map[*modeling.Material]bool)
-
-	for _, mat := range m.Materials() {
-		if mat.Material == nil {
-			if !defaultWritten {
-				if err := WriteMaterial(modeling.DefaultMaterial(), out); err != nil {
-					return fmt.Errorf("failed to write default material: %w", err)
-				}
-				defaultWritten = true
-			}
-			continue
-		}
-
-		if _, ok := written[mat.Material]; ok {
-			continue
-		}
-		if err := WriteMaterial(*mat.Material, out); err != nil {
-			return fmt.Errorf("failed to write material %s: %w", mat.Material.Name, err)
-		}
-		written[mat.Material] = true
-	}
-	return nil
+	return WriteMaterials(m.Materials(), out)
 }
 
 func WriteMaterials(ms []modeling.MeshMaterial, out io.Writer) error {
-	fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform")
+	_, _ = fmt.Fprintln(out, "# Created with github.com/EliCDavis/polyform")
 
 	defaultWritten := false
 

--- a/formats/obj/writer_test.go
+++ b/formats/obj/writer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/EliCDavis/vector/vector2"
 	"github.com/EliCDavis/vector/vector3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteObj_EmptyMesh(t *testing.T) {
@@ -21,7 +22,7 @@ func TestWriteObj_EmptyMesh(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, `# Created with github.com/EliCDavis/polyform
 `, buf.String())
@@ -43,7 +44,7 @@ func TestWriteObj_NoNormalsOrUVs(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
@@ -75,7 +76,7 @@ func TestWriteObj_NoUVs(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
@@ -108,7 +109,7 @@ func TestWriteObj_NoNormals(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
@@ -152,7 +153,7 @@ func TestWriteObj(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
@@ -205,7 +206,7 @@ func TestWriteObjWithSingleMaterial(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
@@ -275,7 +276,7 @@ func TestWriteObjWithMultipleMaterials(t *testing.T) {
 	err := obj.WriteMesh(m, "", &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
@@ -307,6 +308,50 @@ f 4/4/4 5/5/5 6/6/6
 func TestWriteMaterials(t *testing.T) {
 	// ARRANGE ================================================================
 	buf := bytes.Buffer{}
+	ms := []modeling.MeshMaterial{
+		{
+			PrimitiveCount: 1,
+			Material: &modeling.Material{
+				Name:         "red",
+				DiffuseColor: color.RGBA{1, 255, 3, 255},
+			},
+		},
+		{
+			PrimitiveCount: 1,
+			Material: &modeling.Material{
+				Name:          "blue",
+				AmbientColor:  color.RGBA{4, 5, 6, 255},
+				SpecularColor: color.RGBA{7, 8, 9, 255},
+			},
+		},
+	}
+
+	// ACT ====================================================================
+	err := obj.WriteMaterials(ms, &buf)
+
+	// ASSERT =================================================================
+	require.NoError(t, err)
+	assert.Equal(t,
+		`# Created with github.com/EliCDavis/polyform
+newmtl red
+Kd 0.003922 1.000000 0.011765
+Ns 0.000000
+Ni 0.000000
+d 1.000000
+
+newmtl blue
+Ka 0.015686 0.019608 0.023529
+Ks 0.027451 0.031373 0.035294
+Ns 0.000000
+Ni 0.000000
+d 1.000000
+
+`, buf.String())
+}
+
+func TestWriteMaterialsFromMesh(t *testing.T) {
+	// ARRANGE ================================================================
+	buf := bytes.Buffer{}
 	m := modeling.NewTriangleMesh(nil).
 		SetMaterials([]modeling.MeshMaterial{
 			{
@@ -327,10 +372,10 @@ func TestWriteMaterials(t *testing.T) {
 		})
 
 	// ACT ====================================================================
-	err := obj.WriteMaterials(m, &buf)
+	err := obj.WriteMaterialsFromMesh(m, &buf)
 
 	// ASSERT =================================================================
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		`# Created with github.com/EliCDavis/polyform
 newmtl red


### PR DESCRIPTION
This PR adds a `obj.SaveAll(objPath string, meshesToSave map[string]modeling.Mesh)` function to OBJ FS operations. This allows saving multiple named meshes in a single OBJ file. All required internal mechanics for this already exist, i.e. `WriteMeshes()` can already handle this, but this wasn't exposed as an option in FS operations. Now it is.

---
This PR slightly changes the exported interface of the `obj` package - former `WriteMaterials(modeling.Mesh, io.Writer)` is renamed to `WriteMaterialsFromMesh(modeling.Mesh, io.Writer)`, and a new function added under old name, but with a different signature - `WriteMaterials([]modeling.MeshMaterial, io.Writer)`. Examples using those methods are updated accordingly.

This seems more appropriate to me as there is a `WriteMaterial()` func that accepts singular material, and now also `WriteMaterials()` that accepts multiple. Although this isn't perfect by itself since singular is `modeling.Material`, but plural is `[]modeling.MeshMaterial`, slightly different objects.

Naming `WriteMaterialsFromMesh()` seems uncontroversial to me as this is exactly what the method does. Behind the interface `WriteMaterialsFromMesh()` is now a proxy to `WriteMaterials()`, with a convenient interface for the most common use case.

Since `polyform` is at `v0` at the moment - I assume introducing small changes in the exported interfaces of secondary packages is acceptable. Though also I'm happy to rollback and find a different, backwards compatible naming approach if that is preferrable, let me know.

---
If taking exported interface changes further - it would probably make some sense to combine `obj.Save()` and `obj.SaveAll()` into one `obj.Save(objPath string, meshesToSave ...obj.ObjMesh)` interface. But this would introduce more breaking changes, and on the (probably) most widely used function of this package, so I think that's a bridge too far.