### PR TITLE
Deduplicate gltf materials during scene writing

### DIFF
--- a/formats/gltf/material_tracker.go
+++ b/formats/gltf/material_tracker.go
@@ -2,8 +2,8 @@ package gltf
 
 // materialEntry tracks a unique material and its corresponding GLTF material index
 type materialEntry struct {
-	material PolyformMaterial
-	index    int
+	polyMaterial *PolyformMaterial
+	index        int
 }
 
 // materialTracker handles deduplication of GLTF materials
@@ -12,7 +12,7 @@ type materialTracker struct {
 }
 
 // findExistingMaterialID retrieves ID of the material in the tracker, if it exists
-func (mt *materialTracker) findExistingMaterialID(mat PolyformMaterial) (*int, bool) {
+func (mt *materialTracker) findExistingMaterialID(mat *PolyformMaterial) (*int, bool) {
 	for _, entry := range mt.entries {
 		if entry.polyMaterial.equal(mat) {
 			return &entry.index, true

--- a/formats/gltf/material_tracker.go
+++ b/formats/gltf/material_tracker.go
@@ -2,9 +2,8 @@ package gltf
 
 // materialEntry tracks a unique material and its corresponding GLTF material index
 type materialEntry struct {
-	polyMaterial PolyformMaterial
-	gltfMaterial Material
-	index        int
+	material PolyformMaterial
+	index    int
 }
 
 // materialTracker handles deduplication of GLTF materials

--- a/formats/gltf/material_tracker.go
+++ b/formats/gltf/material_tracker.go
@@ -1,0 +1,23 @@
+package gltf
+
+// materialEntry tracks a unique material and its corresponding GLTF material index
+type materialEntry struct {
+	polyMaterial PolyformMaterial
+	gltfMaterial Material
+	index        int
+}
+
+// materialTracker handles deduplication of GLTF materials
+type materialTracker struct {
+	entries []materialEntry
+}
+
+// findExistingMaterialID retrieves ID of the material in the tracker, if it exists
+func (mt *materialTracker) findExistingMaterialID(mat PolyformMaterial) (*int, bool) {
+	for _, entry := range mt.entries {
+		if entry.polyMaterial.equal(mat) {
+			return &entry.index, true
+		}
+	}
+	return nil, false
+}

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -51,3 +51,86 @@ type PolyformTexture struct {
 	URI     string
 	Sampler *Sampler
 }
+
+func (pm PolyformMaterial) equal(other PolyformMaterial) bool {
+	if pm.Name != other.Name {
+		return false
+	}
+	if !pm.PbrMetallicRoughness.equal(other.PbrMetallicRoughness) {
+		return false
+	}
+	if !colorsEqual(pm.EmissiveFactor, other.EmissiveFactor) {
+		return false
+	}
+
+	if (pm.AlphaMode == nil) != (other.AlphaMode == nil) {
+		return false
+	} else if pm.AlphaMode != nil && other.AlphaMode != nil && *pm.AlphaMode != *other.AlphaMode {
+		return false
+	}
+
+	if !float64PtrsEqual(pm.AlphaCutoff, other.AlphaCutoff) {
+		return false
+	}
+	if len(pm.Extensions) != len(other.Extensions) {
+		return false
+	}
+	for i, ext := range pm.Extensions {
+		if i >= len(other.Extensions) || ext != other.Extensions[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (pt *PolyformTexture) equal(other *PolyformTexture) bool {
+	if (pt == nil) != (other == nil) {
+		return false
+	} else if pt == nil {
+		return true
+	}
+	return pt.URI == other.URI
+}
+
+func (pmr *PolyformPbrMetallicRoughness) equal(other *PolyformPbrMetallicRoughness) bool {
+	if (pmr == nil) != (other == nil) {
+		return false
+	}
+	if pmr == nil {
+		return true
+	}
+
+	if !float64PtrsEqual(pmr.MetallicFactor, other.MetallicFactor) ||
+		!float64PtrsEqual(pmr.RoughnessFactor, other.RoughnessFactor) ||
+		!colorsEqual(pmr.BaseColorFactor, other.BaseColorFactor) {
+		return false
+	}
+
+	if !pmr.BaseColorTexture.equal(other.BaseColorTexture) || !pmr.MetallicRoughnessTexture.equal(other.MetallicRoughnessTexture) {
+		return false
+	}
+
+	return true
+}
+
+// Helper functions for comparing nullable values
+func float64PtrsEqual(a, b *float64) bool {
+	if a == nil && b == nil {
+		return true
+	} else if a != nil && b != nil {
+		return *a == *b
+	}
+	return false
+}
+
+func colorsEqual(a, b any) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	} else if a == nil {
+		return true
+	}
+	// Since color.Color is an interface, we can only check for basic RGBA equality
+	r1, g1, b1, a1 := a.(color.Color).RGBA()
+	r2, g2, b2, a2 := b.(color.Color).RGBA()
+	return r1 == r2 && g1 == g2 && b1 == b2 && a1 == a2
+}

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -52,7 +52,11 @@ type PolyformTexture struct {
 	Sampler *Sampler
 }
 
-func (pm PolyformMaterial) equal(other PolyformMaterial) bool {
+func (pm *PolyformMaterial) equal(other *PolyformMaterial) bool {
+	if pm == other {
+		return true
+	}
+
 	if pm.Name != other.Name {
 		return false
 	}
@@ -84,19 +88,39 @@ func (pm PolyformMaterial) equal(other PolyformMaterial) bool {
 }
 
 func (pt *PolyformTexture) equal(other *PolyformTexture) bool {
-	if (pt == nil) != (other == nil) {
-		return false
-	} else if pt == nil {
+	if pt == other {
 		return true
 	}
-	return pt.URI == other.URI
+
+	if pt.URI != other.URI {
+		return false
+	}
+
+	if pt.Sampler == other.Sampler {
+		return true
+	} else if pt.Sampler == nil || other.Sampler == nil {
+		return false
+	}
+
+	if pt.Sampler.MagFilter != other.Sampler.MagFilter ||
+		pt.Sampler.MinFilter != other.Sampler.MinFilter ||
+		pt.Sampler.WrapS != other.Sampler.WrapS ||
+		pt.Sampler.WrapT != other.Sampler.WrapT {
+		return false
+	}
+
+	return true
+}
+
+func (pt *PolyformNormal) equal(other *PolyformNormal) bool {
+	if !pt.PolyformTexture.equal(&other.PolyformTexture) {
+		return false
+	}
+	return float64PtrsEqual(pt.Scale, other.Scale)
 }
 
 func (pmr *PolyformPbrMetallicRoughness) equal(other *PolyformPbrMetallicRoughness) bool {
-	if (pmr == nil) != (other == nil) {
-		return false
-	}
-	if pmr == nil {
+	if pmr == other {
 		return true
 	}
 
@@ -106,7 +130,8 @@ func (pmr *PolyformPbrMetallicRoughness) equal(other *PolyformPbrMetallicRoughne
 		return false
 	}
 
-	if !pmr.BaseColorTexture.equal(other.BaseColorTexture) || !pmr.MetallicRoughnessTexture.equal(other.MetallicRoughnessTexture) {
+	if !pmr.BaseColorTexture.equal(other.BaseColorTexture) ||
+		!pmr.MetallicRoughnessTexture.equal(other.MetallicRoughnessTexture) {
 		return false
 	}
 
@@ -115,19 +140,19 @@ func (pmr *PolyformPbrMetallicRoughness) equal(other *PolyformPbrMetallicRoughne
 
 // Helper functions for comparing nullable values
 func float64PtrsEqual(a, b *float64) bool {
-	if a == nil && b == nil {
+	if a == b {
 		return true
-	} else if a != nil && b != nil {
-		return *a == *b
+	} else if a == nil || b == nil {
+		return false
 	}
-	return false
+	return *a == *b
 }
 
-func colorsEqual(a, b any) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	} else if a == nil {
+func colorsEqual(a, b color.Color) bool {
+	if a == b {
 		return true
+	} else if a == nil || b == nil {
+		return false
 	}
 	// Since color.Color is an interface, we can only check for basic RGBA equality
 	r1, g1, b1, a1 := a.(color.Color).RGBA()

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -76,7 +76,7 @@ func (pm PolyformMaterial) equal(other PolyformMaterial) bool {
 		return false
 	}
 	for i, ext := range pm.Extensions {
-		if i >= len(other.Extensions) || ext != other.Extensions[i] {
+		if ext != other.Extensions[i] {
 			return false
 		}
 	}

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -879,6 +879,311 @@ func TestWriteTexturedTriWithMaterialAlphaCutOffError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWriteTexturedTriWithMaterialsDeduplicated(t *testing.T) {
+	// ARRANGE ================================================================
+	tri1 := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+
+	tri2 := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+
+	buf := bytes.Buffer{}
+
+	// ACT ====================================================================
+	roughness := 0.
+	material := &gltf.PolyformMaterial{
+		Name: "My Material",
+		PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+			BaseColorFactor: color.RGBA{255, 100, 80, 255},
+			RoughnessFactor: &roughness,
+		},
+	}
+	err := gltf.WriteText(gltf.PolyformScene{
+		Models: []gltf.PolyformModel{
+			{Name: "mesh1", Mesh: tri1, Material: material},
+			{Name: "mesh2", Mesh: tri2, Material: material},
+		},
+	}, &buf)
+
+	// ASSERT =================================================================
+	assert.NoError(t, err)
+	stringVal := buf.String()
+
+	assert.Equal(t, `{
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        },
+        {
+            "bufferView": 4,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 5,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 6,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 7,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        }
+    ],
+    "asset": {
+        "version": "2.0",
+        "generator": "https://github.com/EliCDavis/polyform"
+    },
+    "buffers": [
+        {
+            "byteLength": 204,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 72,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 96,
+            "byteLength": 6,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 102,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 138,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 174,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 198,
+            "byteLength": 6,
+            "target": 34963
+        }
+    ],
+    "materials": [
+        {
+            "name": "My Material",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.39215686274509803,
+                    0.3137254901960784,
+                    1
+                ],
+                "roughnessFactor": 0
+            }
+        }
+    ],
+    "meshes": [
+        {
+            "name": "mesh1",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 0,
+                        "POSITION": 1,
+                        "TEXCOORD_0": 2
+                    },
+                    "indices": 3,
+                    "material": 0
+                }
+            ]
+        },
+        {
+            "name": "mesh2",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 4,
+                        "POSITION": 5,
+                        "TEXCOORD_0": 6
+                    },
+                    "indices": 7,
+                    "material": 0
+                }
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0
+        },
+        {
+            "mesh": 1
+        }
+    ],
+    "scenes": [
+        {
+            "nodes": [
+                0,
+                1
+            ]
+        }
+    ]
+}`, stringVal)
+}
+
 func TestWriteEmptyMesh(t *testing.T) {
 	// ARRANGE ================================================================
 	tri := modeling.EmptyMesh(modeling.TriangleTopology)

--- a/formats/gltf/writer.go
+++ b/formats/gltf/writer.go
@@ -332,7 +332,7 @@ func (w *Writer) AddTexture(mat PolyformTexture) *TextureInfo {
 	return newTex
 }
 
-func (w *Writer) AddMaterial(mat PolyformMaterial) (*int, error) {
+func (w *Writer) AddMaterial(mat *PolyformMaterial) (*int, error) {
 	// Check if material already exists
 	if existingId, ok := w.matTracker.findExistingMaterialID(mat); ok {
 		return existingId, nil
@@ -412,7 +412,6 @@ func (w *Writer) AddMaterial(mat PolyformMaterial) (*int, error) {
 	// Add to material tracker
 	w.matTracker.entries = append(w.matTracker.entries, materialEntry{
 		polyMaterial: mat,
-		gltfMaterial: m,
 		index:        index,
 	})
 
@@ -635,7 +634,7 @@ func (w *Writer) AddMesh(model PolyformModel) error {
 	var materialIndex *int
 	var err error
 	if model.Material != nil {
-		materialIndex, err = w.AddMaterial(*model.Material)
+		materialIndex, err = w.AddMaterial(model.Material)
 		if err != nil {
 			return fmt.Errorf("failed to add material %q from model %q: %w", model.Material.Name, model.Name, err)
 		}


### PR DESCRIPTION
This is a new feature for GLTF writer, to deduplicate identical materials and only write the necessary number of unique materials, rather than a material per model. Different models using the same material will correctly reference the single instance of this material.

This improves size of the resulting GLTF/GLB file without changing the functionality in any way. This is adhering to GLTF spec - the separation of materials from models and explicit reference via material index encourages reuse of material objects imo.
