### PR TITLE
Drop floating point noise in color values

### DIFF
--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -412,8 +412,8 @@ func TestWriteTexturedTriWithMaterialWithColor(t *testing.T) {
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
                     1,
-                    0.39215686274509803,
-                    0.3137254901960784,
+                    0.392,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0
@@ -600,8 +600,8 @@ func TestWrite_MaterialAlphaMode(t *testing.T) {
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
                     1,
-                    0.39215686274509803,
-                    0.3137254901960784,
+                    0.392,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0
@@ -791,8 +791,8 @@ func TestWrite_MaterialAlphaModeWithCutOff(t *testing.T) {
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
                     1,
-                    0.39215686274509803,
-                    0.3137254901960784,
+                    0.392,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0
@@ -1135,8 +1135,8 @@ func TestWrite_MaterialsDeduplicated(t *testing.T) {
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
                     1,
-                    0.39215686274509803,
-                    0.3137254901960784,
+                    0.392,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0
@@ -1346,8 +1346,8 @@ func TestWrite_MeshesDeduplicated(t *testing.T) {
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
                     1,
-                    0.39215686274509803,
-                    0.3137254901960784,
+                    0.392,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0
@@ -1653,8 +1653,8 @@ func TestWrite_MeshesDifferentMatsPreserved(t *testing.T) {
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
                     1,
-                    0.39215686274509803,
-                    0.3137254901960784,
+                    0.392,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0
@@ -1664,9 +1664,9 @@ func TestWrite_MeshesDifferentMatsPreserved(t *testing.T) {
             "name": "Material Right",
             "pbrMetallicRoughness": {
                 "baseColorFactor": [
-                    0.39215686274509803,
+                    0.392,
                     1,
-                    0.3137254901960784,
+                    0.314,
                     1
                 ],
                 "roughnessFactor": 0

--- a/formats/gltf/writer.go
+++ b/formats/gltf/writer.go
@@ -316,19 +316,19 @@ func (w *Writer) WriteIndices(indices *iter.ArrayIterator[int], attributeSize in
 func rgbaToFloatArr(c color.Color) [4]float64 {
 	r, g, b, a := c.RGBA()
 	return [4]float64{
-		float64(r) / math.MaxUint16,
-		float64(g) / math.MaxUint16,
-		float64(b) / math.MaxUint16,
-		float64(a) / math.MaxUint16,
+		roundFloat(float64(r)/math.MaxUint16, 3),
+		roundFloat(float64(g)/math.MaxUint16, 3),
+		roundFloat(float64(b)/math.MaxUint16, 3),
+		roundFloat(float64(a)/math.MaxUint16, 3),
 	}
 }
 
 func rgbToFloatArr(c color.Color) [3]float64 {
 	r, g, b, _ := c.RGBA()
 	return [3]float64{
-		float64(r) / math.MaxUint16,
-		float64(g) / math.MaxUint16,
-		float64(b) / math.MaxUint16,
+		roundFloat(float64(r)/math.MaxUint16, 3),
+		roundFloat(float64(g)/math.MaxUint16, 3),
+		roundFloat(float64(b)/math.MaxUint16, 3),
 	}
 }
 
@@ -861,4 +861,17 @@ func (w Writer) WriteGLB(out io.Writer) error {
 	}
 
 	return bitWriter.Error()
+}
+
+// Microvalue, anything below this is assumed to be floating point precision noise and will be discarded.
+const epsilon = 1e-8
+
+func roundFloat(val float64, precision uint) float64 {
+	ratio := math.Pow(10, float64(precision))
+	result := math.Round(val*ratio) / ratio
+	if math.Abs(result) < epsilon {
+		result = 0.0 // remove "-0.0" results
+	}
+
+	return result
 }


### PR DESCRIPTION
This drops the floating point long trails of meaningless dust values in serialised color values. 

I've opted to hardcode it to 3 decimal points because this should fully cover resolution provided by `color.Color` integer values. So no higher precision is necessary here, and this threshold is unlikely to ever change.

This only affects color values since those have well known precision, limited by RGBA data structure. No other values affected.

---
This actually doesn't affect my case, because `draco` transcoder already takes care of it, and even without it the difference is not huge. But it was also very easy to do, so I've dropped this one in.

It didn't need JSON serialisation override, JSON is smart enough to not output trailing zeros, so correct rounding was enough here.