### PR TITLE
Texture extensions

### DIFF
--- a/formats/gltf/extensions.go
+++ b/formats/gltf/extensions.go
@@ -1,8 +1,9 @@
 package gltf
 
 import (
-	"github.com/EliCDavis/vector/vector2"
 	"image/color"
+
+	"github.com/EliCDavis/vector/vector2"
 )
 
 type MaterialExtension interface {

--- a/formats/gltf/extensions.go
+++ b/formats/gltf/extensions.go
@@ -3,8 +3,16 @@ package gltf
 import "image/color"
 
 type MaterialExtension interface {
-	ExtensionID() string
+	MaterialExtensionID() string
 	ToExtensionData(w *Writer) map[string]any
+}
+
+type TextureExtension interface {
+	TextureExtensionID() string
+	ToExtensionData(w *Writer) map[string]any
+
+	// indicates if the extension should be applied to Texture or TextureInfo object
+	IsInfo() bool
 }
 
 // https://kcoley.github.io/glTF/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness/
@@ -38,7 +46,7 @@ type PolyformPbrSpecularGlossiness struct {
 	SpecularGlossinessTexture *PolyformTexture
 }
 
-func (ppsg PolyformPbrSpecularGlossiness) ExtensionID() string {
+func (ppsg PolyformPbrSpecularGlossiness) MaterialExtensionID() string {
 	return "KHR_materials_pbrSpecularGlossiness"
 }
 
@@ -78,7 +86,7 @@ type PolyformTransmission struct {
 	Texture *PolyformTexture
 }
 
-func (tr PolyformTransmission) ExtensionID() string {
+func (tr PolyformTransmission) MaterialExtensionID() string {
 	return "KHR_materials_transmission"
 }
 
@@ -119,7 +127,7 @@ type PolyformVolume struct {
 	AttenuationColor color.Color
 }
 
-func (v PolyformVolume) ExtensionID() string {
+func (v PolyformVolume) MaterialExtensionID() string {
 	return "KHR_materials_volume"
 }
 
@@ -157,7 +165,7 @@ type PolyformIndexOfRefraction struct {
 	IOR *float64
 }
 
-func (sg PolyformIndexOfRefraction) ExtensionID() string {
+func (sg PolyformIndexOfRefraction) MaterialExtensionID() string {
 	return "KHR_materials_ior"
 }
 
@@ -191,7 +199,7 @@ type PolyformSpecular struct {
 	ColorTexture *PolyformTexture
 }
 
-func (ps PolyformSpecular) ExtensionID() string {
+func (ps PolyformSpecular) MaterialExtensionID() string {
 	return "KHR_materials_specular"
 }
 
@@ -220,7 +228,7 @@ func (ps PolyformSpecular) ToExtensionData(w *Writer) map[string]any {
 type PolyformUnlit struct {
 }
 
-func (ps PolyformUnlit) ExtensionID() string {
+func (ps PolyformUnlit) MaterialExtensionID() string {
 	return "KHR_materials_unlit"
 }
 
@@ -238,7 +246,7 @@ type PolyformClearcoat struct {
 	ClearcoatNormalTexture    *PolyformNormal
 }
 
-func (pmc PolyformClearcoat) ExtensionID() string {
+func (pmc PolyformClearcoat) MaterialExtensionID() string {
 	return "KHR_materials_clearcoat"
 }
 
@@ -270,7 +278,7 @@ type PolyformEmissiveStrength struct {
 	EmissiveStrength *float64
 }
 
-func (pmes PolyformEmissiveStrength) ExtensionID() string {
+func (pmes PolyformEmissiveStrength) MaterialExtensionID() string {
 	return "KHR_materials_emissive_strength"
 }
 
@@ -321,7 +329,7 @@ type PolyformIridescence struct {
 	IridescenceThicknessTexture *PolyformTexture
 }
 
-func (pmi PolyformIridescence) ExtensionID() string {
+func (pmi PolyformIridescence) MaterialExtensionID() string {
 	return "KHR_materials_iridescence"
 }
 
@@ -372,7 +380,7 @@ type PolyformSheen struct {
 	SheenRoughnessTexture *PolyformTexture
 }
 
-func (ps PolyformSheen) ExtensionID() string {
+func (ps PolyformSheen) MaterialExtensionID() string {
 	return "KHR_materials_sheen"
 }
 
@@ -417,7 +425,7 @@ type PolyformAnisotropy struct {
 	AnisotropyTexture *PolyformTexture
 }
 
-func (pa PolyformAnisotropy) ExtensionID() string {
+func (pa PolyformAnisotropy) MaterialExtensionID() string {
 	return "KHR_materials_anisotropy"
 }
 
@@ -443,12 +451,46 @@ type PolyformDispersion struct {
 	Dispersion float64
 }
 
-func (pd PolyformDispersion) ExtensionID() string {
+func (pd PolyformDispersion) MaterialExtensionID() string {
 	return "KHR_materials_dispersion"
 }
 
 func (pd PolyformDispersion) ToExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 	metadata["dispersion"] = pd.Dispersion
+	return metadata
+}
+
+// KHR_texture_transform ===================================================
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform
+
+// PolyformTextureTransform is a glTF extension that defines texture transformations.
+type PolyformTextureTransform struct {
+	Offset   *[2]float64 // The offset of the UV coordinate origin as a factor of the texture dimensions.
+	Rotation *float64    // Rotate the UVs by this many radians counter-clockwise around the origin. This is equivalent to a similar rotation of the image clockwise.
+	Scale    *[2]float64 // The scale factor applied to the components of the UV coordinates.
+	TexCoord *int        // Overrides the textureInfo texCoord value if supplied, and if this extension is supported.
+}
+
+func (ptt PolyformTextureTransform) TextureExtensionID() string {
+	return "KHR_texture_transform"
+}
+
+func (ptt PolyformTextureTransform) IsInfo() bool { return true }
+
+func (ptt PolyformTextureTransform) ToExtensionData(w *Writer) map[string]any {
+	metadata := make(map[string]any)
+	if ptt.Offset != nil {
+		metadata["offset"] = *ptt.Offset
+	}
+	if ptt.Rotation != nil {
+		metadata["rotation"] = *ptt.Rotation
+	}
+	if ptt.Scale != nil {
+		metadata["scale"] = *ptt.Scale
+	}
+	if ptt.TexCoord != nil {
+		metadata["texCoord"] = *ptt.TexCoord
+	}
 	return metadata
 }

--- a/formats/gltf/extensions.go
+++ b/formats/gltf/extensions.go
@@ -1,6 +1,9 @@
 package gltf
 
-import "image/color"
+import (
+	"github.com/EliCDavis/vector/vector2"
+	"image/color"
+)
 
 type MaterialExtension interface {
 	ExtensionID() string
@@ -473,10 +476,10 @@ type PolyformTextureTransform struct {
 	// If set - extension will be added to `extensionsRequired` list at the GLTF file top level.
 	Required bool
 
-	Offset   *[2]float64 // The offset of the UV coordinate origin as a factor of the texture dimensions.
-	Rotation *float64    // Rotate the UVs by this many radians counter-clockwise around the origin. This is equivalent to a similar rotation of the image clockwise.
-	Scale    *[2]float64 // The scale factor applied to the components of the UV coordinates.
-	TexCoord *int        // Overrides the textureInfo texCoord value if supplied, and if this extension is supported.
+	Offset   *vector2.Float64 // The offset of the UV coordinate origin as a factor of the texture dimensions.
+	Rotation *float64         // Rotate the UVs by this many radians counter-clockwise around the origin. This is equivalent to a similar rotation of the image clockwise.
+	Scale    *vector2.Float64 // The scale factor applied to the components of the UV coordinates.
+	TexCoord *int             // Overrides the textureInfo texCoord value if supplied, and if this extension is supported.
 }
 
 func (ptt PolyformTextureTransform) ExtensionID() string {
@@ -489,13 +492,13 @@ func (ptt PolyformTextureTransform) IsInfo() bool     { return true }
 func (ptt PolyformTextureTransform) ToTextureExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 	if ptt.Offset != nil {
-		metadata["offset"] = *ptt.Offset
+		metadata["offset"] = ptt.Offset.ToFixedArr()
 	}
 	if ptt.Rotation != nil {
 		metadata["rotation"] = *ptt.Rotation
 	}
 	if ptt.Scale != nil {
-		metadata["scale"] = *ptt.Scale
+		metadata["scale"] = ptt.Scale.ToFixedArr()
 	}
 	if ptt.TexCoord != nil {
 		metadata["texCoord"] = *ptt.TexCoord

--- a/formats/gltf/extensions.go
+++ b/formats/gltf/extensions.go
@@ -3,13 +3,14 @@ package gltf
 import "image/color"
 
 type MaterialExtension interface {
-	MaterialExtensionID() string
-	ToExtensionData(w *Writer) map[string]any
+	ExtensionID() string
+	ToMaterialExtensionData(w *Writer) map[string]any
 }
 
 type TextureExtension interface {
-	TextureExtensionID() string
-	ToExtensionData(w *Writer) map[string]any
+	ExtensionID() string
+	ToTextureExtensionData(w *Writer) map[string]any
+	IsRequired() bool
 
 	// indicates if the extension should be applied to Texture or TextureInfo object
 	IsInfo() bool
@@ -46,11 +47,11 @@ type PolyformPbrSpecularGlossiness struct {
 	SpecularGlossinessTexture *PolyformTexture
 }
 
-func (ppsg PolyformPbrSpecularGlossiness) MaterialExtensionID() string {
+func (ppsg PolyformPbrSpecularGlossiness) ExtensionID() string {
 	return "KHR_materials_pbrSpecularGlossiness"
 }
 
-func (sg PolyformPbrSpecularGlossiness) ToExtensionData(w *Writer) map[string]any {
+func (sg PolyformPbrSpecularGlossiness) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 	if sg.DiffuseFactor != nil {
 		metadata["diffuseFactor"] = rgbaToFloatArr(sg.DiffuseFactor)
@@ -86,11 +87,11 @@ type PolyformTransmission struct {
 	Texture *PolyformTexture
 }
 
-func (tr PolyformTransmission) MaterialExtensionID() string {
+func (tr PolyformTransmission) ExtensionID() string {
 	return "KHR_materials_transmission"
 }
 
-func (tr PolyformTransmission) ToExtensionData(w *Writer) map[string]any {
+func (tr PolyformTransmission) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	metadata["transmissionFactor"] = tr.Factor
@@ -127,11 +128,11 @@ type PolyformVolume struct {
 	AttenuationColor color.Color
 }
 
-func (v PolyformVolume) MaterialExtensionID() string {
+func (v PolyformVolume) ExtensionID() string {
 	return "KHR_materials_volume"
 }
 
-func (v PolyformVolume) ToExtensionData(w *Writer) map[string]any {
+func (v PolyformVolume) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	metadata["thicknessFactor"] = v.ThicknessFactor
@@ -165,11 +166,11 @@ type PolyformIndexOfRefraction struct {
 	IOR *float64
 }
 
-func (sg PolyformIndexOfRefraction) MaterialExtensionID() string {
+func (sg PolyformIndexOfRefraction) ExtensionID() string {
 	return "KHR_materials_ior"
 }
 
-func (sg PolyformIndexOfRefraction) ToExtensionData(w *Writer) map[string]any {
+func (sg PolyformIndexOfRefraction) ToMaterialExtensionData(w *Writer) map[string]any {
 	if sg.IOR == nil {
 		return map[string]any{}
 	}
@@ -199,11 +200,11 @@ type PolyformSpecular struct {
 	ColorTexture *PolyformTexture
 }
 
-func (ps PolyformSpecular) MaterialExtensionID() string {
+func (ps PolyformSpecular) ExtensionID() string {
 	return "KHR_materials_specular"
 }
 
-func (ps PolyformSpecular) ToExtensionData(w *Writer) map[string]any {
+func (ps PolyformSpecular) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	if ps.Factor != nil {
@@ -228,11 +229,11 @@ func (ps PolyformSpecular) ToExtensionData(w *Writer) map[string]any {
 type PolyformUnlit struct {
 }
 
-func (ps PolyformUnlit) MaterialExtensionID() string {
+func (ps PolyformUnlit) ExtensionID() string {
 	return "KHR_materials_unlit"
 }
 
-func (ps PolyformUnlit) ToExtensionData(w *Writer) map[string]any {
+func (ps PolyformUnlit) ToMaterialExtensionData(w *Writer) map[string]any {
 	return make(map[string]any)
 }
 
@@ -246,11 +247,11 @@ type PolyformClearcoat struct {
 	ClearcoatNormalTexture    *PolyformNormal
 }
 
-func (pmc PolyformClearcoat) MaterialExtensionID() string {
+func (pmc PolyformClearcoat) ExtensionID() string {
 	return "KHR_materials_clearcoat"
 }
 
-func (pmc PolyformClearcoat) ToExtensionData(w *Writer) map[string]any {
+func (pmc PolyformClearcoat) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	metadata["clearcoatFactor"] = pmc.ClearcoatFactor
@@ -278,11 +279,11 @@ type PolyformEmissiveStrength struct {
 	EmissiveStrength *float64
 }
 
-func (pmes PolyformEmissiveStrength) MaterialExtensionID() string {
+func (pmes PolyformEmissiveStrength) ExtensionID() string {
 	return "KHR_materials_emissive_strength"
 }
 
-func (pmes PolyformEmissiveStrength) ToExtensionData(w *Writer) map[string]any {
+func (pmes PolyformEmissiveStrength) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	if pmes.EmissiveStrength != nil {
@@ -329,11 +330,11 @@ type PolyformIridescence struct {
 	IridescenceThicknessTexture *PolyformTexture
 }
 
-func (pmi PolyformIridescence) MaterialExtensionID() string {
+func (pmi PolyformIridescence) ExtensionID() string {
 	return "KHR_materials_iridescence"
 }
 
-func (pmi PolyformIridescence) ToExtensionData(w *Writer) map[string]any {
+func (pmi PolyformIridescence) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	metadata["iridescenceFactor"] = pmi.IridescenceFactor
@@ -380,11 +381,11 @@ type PolyformSheen struct {
 	SheenRoughnessTexture *PolyformTexture
 }
 
-func (ps PolyformSheen) MaterialExtensionID() string {
+func (ps PolyformSheen) ExtensionID() string {
 	return "KHR_materials_sheen"
 }
 
-func (ps PolyformSheen) ToExtensionData(w *Writer) map[string]any {
+func (ps PolyformSheen) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	if ps.SheenColorFactor != nil {
@@ -425,11 +426,11 @@ type PolyformAnisotropy struct {
 	AnisotropyTexture *PolyformTexture
 }
 
-func (pa PolyformAnisotropy) MaterialExtensionID() string {
+func (pa PolyformAnisotropy) ExtensionID() string {
 	return "KHR_materials_anisotropy"
 }
 
-func (pa PolyformAnisotropy) ToExtensionData(w *Writer) map[string]any {
+func (pa PolyformAnisotropy) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 
 	metadata["anisotropyStrength"] = pa.AnisotropyStrength
@@ -451,11 +452,11 @@ type PolyformDispersion struct {
 	Dispersion float64
 }
 
-func (pd PolyformDispersion) MaterialExtensionID() string {
+func (pd PolyformDispersion) ExtensionID() string {
 	return "KHR_materials_dispersion"
 }
 
-func (pd PolyformDispersion) ToExtensionData(w *Writer) map[string]any {
+func (pd PolyformDispersion) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 	metadata["dispersion"] = pd.Dispersion
 	return metadata
@@ -464,21 +465,28 @@ func (pd PolyformDispersion) ToExtensionData(w *Writer) map[string]any {
 // KHR_texture_transform ===================================================
 // https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform
 
+var _ TextureExtension = PolyformTextureTransform{}
+
 // PolyformTextureTransform is a glTF extension that defines texture transformations.
 type PolyformTextureTransform struct {
+	// Whether to make this extension required for the given model.
+	// If set - extension will be added to `extensionsRequired` list at the GLTF file top level.
+	Required bool
+
 	Offset   *[2]float64 // The offset of the UV coordinate origin as a factor of the texture dimensions.
 	Rotation *float64    // Rotate the UVs by this many radians counter-clockwise around the origin. This is equivalent to a similar rotation of the image clockwise.
 	Scale    *[2]float64 // The scale factor applied to the components of the UV coordinates.
 	TexCoord *int        // Overrides the textureInfo texCoord value if supplied, and if this extension is supported.
 }
 
-func (ptt PolyformTextureTransform) TextureExtensionID() string {
+func (ptt PolyformTextureTransform) ExtensionID() string {
 	return "KHR_texture_transform"
 }
 
-func (ptt PolyformTextureTransform) IsInfo() bool { return true }
+func (ptt PolyformTextureTransform) IsRequired() bool { return ptt.Required }
+func (ptt PolyformTextureTransform) IsInfo() bool     { return true }
 
-func (ptt PolyformTextureTransform) ToExtensionData(w *Writer) map[string]any {
+func (ptt PolyformTextureTransform) ToTextureExtensionData(w *Writer) map[string]any {
 	metadata := make(map[string]any)
 	if ptt.Offset != nil {
 		metadata["offset"] = *ptt.Offset

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -1,11 +1,11 @@
 package gltf_test
 
 import (
-	"github.com/EliCDavis/vector/vector2"
 	"image/color"
 	"testing"
 
 	"github.com/EliCDavis/polyform/formats/gltf"
+	"github.com/EliCDavis/vector/vector2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -1,6 +1,7 @@
 package gltf_test
 
 import (
+	"github.com/EliCDavis/vector/vector2"
 	"image/color"
 	"testing"
 
@@ -501,11 +502,11 @@ func TestTextureExtension_ToExtensionData(t *testing.T) {
 		want      map[string]any
 	}{
 		"TextureTransform/scale": {
-			extension: gltf.PolyformTextureTransform{Scale: pointer([2]float64{1.0, 0.0})},
+			extension: gltf.PolyformTextureTransform{Scale: pointer(vector2.New[float64](1.0, 0.0))},
 			want:      map[string]any{"scale": [2]float64{1.0, 0.0}},
 		},
 		"TextureTransform/offset": {
-			extension: gltf.PolyformTextureTransform{Offset: pointer([2]float64{1.0, 0.0})},
+			extension: gltf.PolyformTextureTransform{Offset: pointer(vector2.New[float64](1.0, 0.0))},
 			want:      map[string]any{"offset": [2]float64{1.0, 0.0}},
 		},
 		"TextureTransform/rotation": {
@@ -518,8 +519,8 @@ func TestTextureExtension_ToExtensionData(t *testing.T) {
 		},
 		"TextureTransform/altogether": {
 			extension: gltf.PolyformTextureTransform{
-				Offset:   pointer([2]float64{1.0, 0.0}),
-				Scale:    pointer([2]float64{1.0, 0.0}),
+				Offset:   pointer(vector2.New[float64](1.0, 0.0)),
+				Scale:    pointer(vector2.New[float64](1.0, 0.0)),
 				Rotation: pointer(1.0),
 				TexCoord: pointer(1),
 			},

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Pointer[T any](v T) *T {
+func pointer[T any](v T) *T {
 	return &v
 }
 
-func TestExtensionsID(t *testing.T) {
+func TestMaterialExtensionsID(t *testing.T) {
 	tests := map[string]struct {
 		extension gltf.MaterialExtension
 		want      string
@@ -69,7 +69,25 @@ func TestExtensionsID(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.extension.ExtensionID())
+			assert.Equal(t, tc.want, tc.extension.MaterialExtensionID())
+		})
+	}
+}
+
+func TestTextureExtensionsID(t *testing.T) {
+	tests := map[string]struct {
+		extension gltf.TextureExtension
+		want      string
+	}{
+		"transform": {
+			extension: gltf.PolyformTextureTransform{},
+			want:      "KHR_texture_transform",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.extension.TextureExtensionID())
 		})
 	}
 }
@@ -117,7 +135,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"SpecularGlossiness/glossinessFactor": {
 			extension: gltf.PolyformPbrSpecularGlossiness{
-				GlossinessFactor: Pointer(1.),
+				GlossinessFactor: pointer(1.),
 			},
 			want: map[string]any{
 				"glossinessFactor": 1.,
@@ -136,7 +154,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 				DiffuseFactor:             color.Black,
 				SpecularFactor:            color.White,
 				DiffuseTexture:            &gltf.PolyformTexture{},
-				GlossinessFactor:          Pointer(.5),
+				GlossinessFactor:          pointer(.5),
 				SpecularGlossinessTexture: &gltf.PolyformTexture{},
 			},
 			want: map[string]any{
@@ -182,7 +200,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"Iridescence/iridescenceIor": {
 			extension: gltf.PolyformIridescence{
-				IridescenceIor: Pointer(1.),
+				IridescenceIor: pointer(1.),
 			},
 			want: map[string]any{
 				"iridescenceFactor": 0.,
@@ -191,7 +209,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"Iridescence/iridescenceThicknessMinimum": {
 			extension: gltf.PolyformIridescence{
-				IridescenceThicknessMinimum: Pointer(1.),
+				IridescenceThicknessMinimum: pointer(1.),
 			},
 			want: map[string]any{
 				"iridescenceFactor":           0.,
@@ -200,7 +218,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"Iridescence/iridescenceThicknessMaximum": {
 			extension: gltf.PolyformIridescence{
-				IridescenceThicknessMaximum: Pointer(1.),
+				IridescenceThicknessMaximum: pointer(1.),
 			},
 			want: map[string]any{
 				"iridescenceFactor":           0.,
@@ -220,9 +238,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 			extension: gltf.PolyformIridescence{
 				IridescenceFactor:           1,
 				IridescenceTexture:          &gltf.PolyformTexture{},
-				IridescenceIor:              Pointer(1.),
-				IridescenceThicknessMinimum: Pointer(1.),
-				IridescenceThicknessMaximum: Pointer(1.),
+				IridescenceIor:              pointer(1.),
+				IridescenceThicknessMinimum: pointer(1.),
+				IridescenceThicknessMaximum: pointer(1.),
 				IridescenceThicknessTexture: &gltf.PolyformTexture{},
 			},
 			want: map[string]any{
@@ -324,7 +342,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"EmissiveStrength/everything": {
 			extension: gltf.PolyformEmissiveStrength{
-				EmissiveStrength: Pointer(1.0),
+				EmissiveStrength: pointer(1.0),
 			},
 			want: map[string]any{
 				"emissiveStrength": 1.,
@@ -336,7 +354,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"IndexOfRefraction/everything": {
 			extension: gltf.PolyformIndexOfRefraction{
-				IOR: Pointer(1.0),
+				IOR: pointer(1.0),
 			},
 			want: map[string]any{
 				"ior": 1.,
@@ -359,7 +377,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"Volume/attenuationDistance": {
 			extension: gltf.PolyformVolume{
-				AttenuationDistance: Pointer(1.),
+				AttenuationDistance: pointer(1.),
 			},
 			want: map[string]any{
 				"thicknessFactor":     0.,
@@ -379,7 +397,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 			extension: gltf.PolyformVolume{
 				ThicknessFactor:     1.,
 				ThicknessTexture:    &gltf.PolyformTexture{},
-				AttenuationDistance: Pointer(1.),
+				AttenuationDistance: pointer(1.),
 				AttenuationColor:    color.White,
 			},
 			want: map[string]any{
@@ -395,7 +413,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"Specular/specularFactor": {
 			extension: gltf.PolyformSpecular{
-				Factor: Pointer(1.),
+				Factor: pointer(1.),
 			},
 			want: map[string]any{
 				"specularFactor": 1.0,
@@ -427,7 +445,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		},
 		"Specular/everything": {
 			extension: gltf.PolyformSpecular{
-				Factor:       Pointer(1.),
+				Factor:       pointer(1.),
 				Texture:      &gltf.PolyformTexture{},
 				ColorFactor:  color.White,
 				ColorTexture: &gltf.PolyformTexture{},
@@ -437,6 +455,79 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 				"specularTexture":      &gltf.TextureInfo{},
 				"specularColorFactor":  [3]float64{1., 1., 1.},
 				"specularColorTexture": &gltf.TextureInfo{Index: 1},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			writer := gltf.NewWriter()
+			data := tc.extension.ToExtensionData(writer)
+
+			if !assert.Len(t, data, len(tc.want)) {
+				return
+			}
+
+			for k, v := range tc.want {
+				assert.Equal(t, v, data[k])
+			}
+		})
+	}
+}
+
+func TestTextureExtension_IsInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		extension gltf.TextureExtension
+		want      bool
+	}{
+		{
+			name:      "TextureTransform",
+			extension: gltf.PolyformTextureTransform{},
+			want:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.extension.IsInfo(), tc.want)
+		})
+	}
+}
+
+func TestTextureExtension_ToExtensionData(t *testing.T) {
+	tests := map[string]struct {
+		extension gltf.TextureExtension
+		want      map[string]any
+	}{
+		"TextureTransform/scale": {
+			extension: gltf.PolyformTextureTransform{Scale: pointer([2]float64{1.0, 0.0})},
+			want:      map[string]any{"scale": [2]float64{1.0, 0.0}},
+		},
+		"TextureTransform/offset": {
+			extension: gltf.PolyformTextureTransform{Offset: pointer([2]float64{1.0, 0.0})},
+			want:      map[string]any{"offset": [2]float64{1.0, 0.0}},
+		},
+		"TextureTransform/rotation": {
+			extension: gltf.PolyformTextureTransform{Rotation: pointer(1.0)},
+			want:      map[string]any{"rotation": 1.0},
+		},
+		"TextureTransform/texCoord": {
+			extension: gltf.PolyformTextureTransform{TexCoord: pointer(1)},
+			want:      map[string]any{"texCoord": 1},
+		},
+		"TextureTransform/altogether": {
+			extension: gltf.PolyformTextureTransform{
+				Offset:   pointer([2]float64{1.0, 0.0}),
+				Scale:    pointer([2]float64{1.0, 0.0}),
+				Rotation: pointer(1.0),
+				TexCoord: pointer(1),
+			},
+			want: map[string]any{
+				"scale":    [2]float64{1.0, 0.0},
+				"offset":   [2]float64{1.0, 0.0},
+				"rotation": 1.0,
+				"texCoord": 1,
 			},
 		},
 	}

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -69,7 +69,7 @@ func TestMaterialExtensionsID(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.extension.MaterialExtensionID())
+			assert.Equal(t, tc.want, tc.extension.ExtensionID())
 		})
 	}
 }
@@ -87,7 +87,7 @@ func TestTextureExtensionsID(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.extension.TextureExtensionID())
+			assert.Equal(t, tc.want, tc.extension.ExtensionID())
 		})
 	}
 }
@@ -462,7 +462,7 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			writer := gltf.NewWriter()
-			data := tc.extension.ToExtensionData(writer)
+			data := tc.extension.ToMaterialExtensionData(writer)
 
 			if !assert.Len(t, data, len(tc.want)) {
 				return
@@ -535,7 +535,7 @@ func TestTextureExtension_ToExtensionData(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			writer := gltf.NewWriter()
-			data := tc.extension.ToExtensionData(writer)
+			data := tc.extension.ToTextureExtensionData(writer)
 
 			if !assert.Len(t, data, len(tc.want)) {
 				return

--- a/formats/gltf/material.go
+++ b/formats/gltf/material.go
@@ -15,8 +15,9 @@ type PbrMetallicRoughness struct {
 // https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/textureInfo.schema.json
 type TextureInfo struct {
 	Property
-	Index    GltfId `json:"index"`              // The index of the texture.
-	TexCoord int    `json:"texCoord,omitempty"` // "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in `mesh.primitives.attributes` (e.g. a value of `0` corresponds to `TEXCOORD_0`). A mesh primitive **MUST** have the corresponding texture coordinate attributes for the material to be applicable to it.
+	Index      GltfId     `json:"index"`              // The index of the texture.
+	TexCoord   int        `json:"texCoord,omitempty"` // "This integer value is used to construct a string in the format `TEXCOORD_<set index>` which is a reference to a key in `mesh.primitives.attributes` (e.g. a value of `0` corresponds to `TEXCOORD_0`). A mesh primitive **MUST** have the corresponding texture coordinate attributes for the material to be applicable to it.
+	Extensions Extensions `json:"extensions,omitempty"`
 }
 
 type NormalTexture struct {

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -59,8 +59,9 @@ type PolyformNormal struct {
 }
 
 type PolyformTexture struct {
-	URI     string
-	Sampler *Sampler
+	URI        string
+	Sampler    *Sampler
+	Extensions []TextureExtension
 }
 
 func (pm *PolyformMaterial) equal(other *PolyformMaterial) bool {

--- a/formats/gltf/structure.go
+++ b/formats/gltf/structure.go
@@ -104,8 +104,9 @@ type Image struct {
 // https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/texture.schema.json
 type Texture struct {
 	ChildOfRootProperty
-	Sampler *GltfId `json:"sampler,omitempty"`
-	Source  *GltfId `json:"source,omitempty"`
+	Sampler    *GltfId    `json:"sampler,omitempty"`
+	Source     *GltfId    `json:"source,omitempty"`
+	Extensions Extensions `json:"extensions,omitempty"`
 }
 
 // Joints and matrices defining a skin.

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -715,6 +715,242 @@ func TestWrite_TexturedTriWithTexExtension(t *testing.T) {
 }`, buf.String())
 }
 
+func TestWrite_TexturedTriWithTexExtension_Required(t *testing.T) {
+	// ARRANGE ================================================================
+	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+
+	buf := bytes.Buffer{}
+
+	// ACT ====================================================================
+	roughness := 0.
+	textureOffset := [2]float64{1.1, 0.1}
+	err := gltf.WriteText(gltf.PolyformScene{
+		Models: []gltf.PolyformModel{
+			{
+				Name: "mesh",
+				Mesh: &tri,
+				Material: &gltf.PolyformMaterial{
+					Name: "My Material",
+					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+						BaseColorFactor: color.RGBA{255, 100, 80, 255},
+						RoughnessFactor: &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{
+							URI: "this_is_a_test.png",
+							Sampler: &gltf.Sampler{
+								WrapS:     gltf.SamplerWrap_REPEAT,
+								WrapT:     gltf.SamplerWrap_REPEAT,
+								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+								MagFilter: gltf.SamplerMagFilter_LINEAR,
+							},
+							Extensions: []gltf.TextureExtension{gltf.PolyformTextureTransform{
+								Required: true,
+								Offset:   &textureOffset,
+							}},
+						},
+					},
+				},
+			},
+		},
+	}, &buf)
+
+	// ASSERT =================================================================
+	assert.NoError(t, err)
+	assert.Equal(t, `{
+    "extensionsUsed": [
+        "KHR_texture_transform"
+    ],
+    "extensionsRequired": [
+        "KHR_texture_transform"
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        }
+    ],
+    "asset": {
+        "version": "2.0",
+        "generator": "https://github.com/EliCDavis/polyform"
+    },
+    "buffers": [
+        {
+            "byteLength": 102,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 72,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 96,
+            "byteLength": 6,
+            "target": 34963
+        }
+    ],
+    "images": [
+        {
+            "uri": "this_is_a_test.png"
+        }
+    ],
+    "materials": [
+        {
+            "name": "My Material",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "baseColorTexture": {
+                    "index": 0,
+                    "extensions": {
+                        "KHR_texture_transform": {
+                            "offset": [
+                                1.1,
+                                0.1
+                            ]
+                        }
+                    }
+                },
+                "roughnessFactor": 0
+            }
+        }
+    ],
+    "meshes": [
+        {
+            "name": "mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 0,
+                        "POSITION": 1,
+                        "TEXCOORD_0": 2
+                    },
+                    "indices": 3,
+                    "material": 0
+                }
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0,
+            "name": "mesh"
+        }
+    ],
+    "samplers": [
+        {
+            "magFilter": 9729,
+            "minFilter": 9987,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    ],
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "textures": [
+        {
+            "sampler": 0,
+            "source": 0
+        }
+    ]
+}`, buf.String())
+}
+
 func TestWrite_MaterialAlphaMode(t *testing.T) {
 	// ARRANGE ================================================================
 	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -3,12 +3,12 @@ package gltf_test
 import (
 	"bytes"
 	"errors"
-	"github.com/EliCDavis/polyform/math/quaternion"
 	"image/color"
 	"math"
 	"testing"
 
 	"github.com/EliCDavis/polyform/formats/gltf"
+	"github.com/EliCDavis/polyform/math/quaternion"
 	"github.com/EliCDavis/polyform/modeling"
 	"github.com/EliCDavis/vector/vector2"
 	"github.com/EliCDavis/vector/vector3"

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -483,6 +483,238 @@ func TestWrite_TexturedTriWithMaterialWithColor(t *testing.T) {
 }`, buf.String())
 }
 
+func TestWrite_TexturedTriWithTexExtension(t *testing.T) {
+	// ARRANGE ================================================================
+	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+
+	buf := bytes.Buffer{}
+
+	// ACT ====================================================================
+	roughness := 0.
+	textureOffset := [2]float64{1.1, 0.1}
+	err := gltf.WriteText(gltf.PolyformScene{
+		Models: []gltf.PolyformModel{
+			{
+				Name: "mesh",
+				Mesh: &tri,
+				Material: &gltf.PolyformMaterial{
+					Name: "My Material",
+					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+						BaseColorFactor: color.RGBA{255, 100, 80, 255},
+						RoughnessFactor: &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{
+							URI: "this_is_a_test.png",
+							Sampler: &gltf.Sampler{
+								WrapS:     gltf.SamplerWrap_REPEAT,
+								WrapT:     gltf.SamplerWrap_REPEAT,
+								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+								MagFilter: gltf.SamplerMagFilter_LINEAR,
+							},
+							Extensions: []gltf.TextureExtension{gltf.PolyformTextureTransform{
+								Offset: &textureOffset,
+							}},
+						},
+					},
+				},
+			},
+		},
+	}, &buf)
+
+	// ASSERT =================================================================
+	assert.NoError(t, err)
+	assert.Equal(t, `{
+    "extensionsUsed": [
+        "KHR_texture_transform"
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        }
+    ],
+    "asset": {
+        "version": "2.0",
+        "generator": "https://github.com/EliCDavis/polyform"
+    },
+    "buffers": [
+        {
+            "byteLength": 102,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 72,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 96,
+            "byteLength": 6,
+            "target": 34963
+        }
+    ],
+    "images": [
+        {
+            "uri": "this_is_a_test.png"
+        }
+    ],
+    "materials": [
+        {
+            "name": "My Material",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "baseColorTexture": {
+                    "index": 0,
+                    "extensions": {
+                        "KHR_texture_transform": {
+                            "offset": [
+                                1.1,
+                                0.1
+                            ]
+                        }
+                    }
+                },
+                "roughnessFactor": 0
+            }
+        }
+    ],
+    "meshes": [
+        {
+            "name": "mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 0,
+                        "POSITION": 1,
+                        "TEXCOORD_0": 2
+                    },
+                    "indices": 3,
+                    "material": 0
+                }
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0,
+            "name": "mesh"
+        }
+    ],
+    "samplers": [
+        {
+            "magFilter": 9729,
+            "minFilter": 9987,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    ],
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "textures": [
+        {
+            "sampler": 0,
+            "source": 0
+        }
+    ]
+}`, buf.String())
+}
+
 func TestWrite_MaterialAlphaMode(t *testing.T) {
 	// ARRANGE ================================================================
 	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -515,7 +515,7 @@ func TestWrite_TexturedTriWithTexExtension(t *testing.T) {
 
 	// ACT ====================================================================
 	roughness := 0.
-	textureOffset := [2]float64{1.1, 0.1}
+	textureOffset := vector2.New[float64](1.1, 0.1)
 	err := gltf.WriteText(gltf.PolyformScene{
 		Models: []gltf.PolyformModel{
 			{
@@ -747,7 +747,7 @@ func TestWrite_TexturedTriWithTexExtension_Required(t *testing.T) {
 
 	// ACT ====================================================================
 	roughness := 0.
-	textureOffset := [2]float64{1.1, 0.1}
+	textureOffset := vector2.New[float64](1.1, 0.1)
 	err := gltf.WriteText(gltf.PolyformScene{
 		Models: []gltf.PolyformModel{
 			{

--- a/formats/gltf/writer.go
+++ b/formats/gltf/writer.go
@@ -526,7 +526,7 @@ func (w *Writer) AddTexture(polyTex PolyformTexture) *TextureInfo {
 	w.images = append(w.images, Image{
 		URI: polyTex.URI,
 	})
-	var sampler Sampler{}
+	var sampler Sampler
 	if polyTex.Sampler != nil {
 		sampler = *polyTex.Sampler
 	}


### PR DESCRIPTION
_~this is based on and should be merged after #45~_ _merged_

This PR adds an ability to set texture extensions, and `KHR_texture_transform`  as the first of the kind. 

This uses existing extensions pattern, but creates a new type for `TextureExtension`, not to be confused with `MaterialExtension`. `MaterialExtension` type is amended (`ExtensionID` renamed to `MaterialExtensionID`) to make sure these interfaces are not compatible and there is no confusion between different types of extensions.

Texture extensions are a bit awkward, as they can be added to `texture` or to `textureInfo` objects. Since these are closely related - I opted to add a flag on the extension itself, rather than create two different types of `TextureExtension` and `TextureInfoExtension`. 

This PR adds support for adding extension to both/either, although the only existing extension is for `TextureInfo`. Extension separation happens using the flag, right in the `writer.AddTexture` method. 

---
Also fixes a typo I accidentally in the previous PR :D 