### PR TITLE
Deduplicate images, samplers, textures

### DIFF
--- a/formats/gltf/extensions.go
+++ b/formats/gltf/extensions.go
@@ -62,7 +62,7 @@ func (sg PolyformPbrSpecularGlossiness) ToMaterialExtensionData(w *Writer) map[s
 	}
 
 	if sg.DiffuseTexture != nil {
-		metadata["diffuseTexture"] = w.AddTexture(*sg.DiffuseTexture)
+		metadata["diffuseTexture"] = w.AddTexture(sg.DiffuseTexture)
 	}
 
 	if sg.SpecularFactor != nil {
@@ -74,7 +74,7 @@ func (sg PolyformPbrSpecularGlossiness) ToMaterialExtensionData(w *Writer) map[s
 	}
 
 	if sg.SpecularGlossinessTexture != nil {
-		metadata["specularGlossinessTexture"] = w.AddTexture(*sg.SpecularGlossinessTexture)
+		metadata["specularGlossinessTexture"] = w.AddTexture(sg.SpecularGlossinessTexture)
 	}
 	return metadata
 }
@@ -101,7 +101,7 @@ func (tr PolyformTransmission) ToMaterialExtensionData(w *Writer) map[string]any
 	metadata["transmissionFactor"] = tr.Factor
 
 	if tr.Texture != nil {
-		metadata["transmissionTexture"] = w.AddTexture(*tr.Texture)
+		metadata["transmissionTexture"] = w.AddTexture(tr.Texture)
 	}
 
 	return metadata
@@ -142,7 +142,7 @@ func (v PolyformVolume) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata["thicknessFactor"] = v.ThicknessFactor
 
 	if v.ThicknessTexture != nil {
-		metadata["thicknessTexture"] = w.AddTexture(*v.ThicknessTexture)
+		metadata["thicknessTexture"] = w.AddTexture(v.ThicknessTexture)
 	}
 
 	if v.AttenuationDistance != nil {
@@ -216,7 +216,7 @@ func (ps PolyformSpecular) ToMaterialExtensionData(w *Writer) map[string]any {
 	}
 
 	if ps.Texture != nil {
-		metadata["specularTexture"] = w.AddTexture(*ps.Texture)
+		metadata["specularTexture"] = w.AddTexture(ps.Texture)
 	}
 
 	if ps.ColorFactor != nil {
@@ -224,7 +224,7 @@ func (ps PolyformSpecular) ToMaterialExtensionData(w *Writer) map[string]any {
 	}
 
 	if ps.ColorTexture != nil {
-		metadata["specularColorTexture"] = w.AddTexture(*ps.ColorTexture)
+		metadata["specularColorTexture"] = w.AddTexture(ps.ColorTexture)
 	}
 
 	return metadata
@@ -260,12 +260,12 @@ func (pmc PolyformClearcoat) ToMaterialExtensionData(w *Writer) map[string]any {
 
 	metadata["clearcoatFactor"] = pmc.ClearcoatFactor
 	if pmc.ClearcoatTexture != nil {
-		metadata["clearcoatTexture"] = w.AddTexture(*pmc.ClearcoatTexture)
+		metadata["clearcoatTexture"] = w.AddTexture(pmc.ClearcoatTexture)
 	}
 
 	metadata["clearcoatRoughnessFactor"] = pmc.ClearcoatRoughnessFactor
 	if pmc.ClearcoatRoughnessTexture != nil {
-		metadata["clearcoatRoughnessTexture"] = w.AddTexture(*pmc.ClearcoatRoughnessTexture)
+		metadata["clearcoatRoughnessTexture"] = w.AddTexture(pmc.ClearcoatRoughnessTexture)
 	}
 
 	// if pmc.ClearcoatNormalTexture != nil {
@@ -344,7 +344,7 @@ func (pmi PolyformIridescence) ToMaterialExtensionData(w *Writer) map[string]any
 	metadata["iridescenceFactor"] = pmi.IridescenceFactor
 
 	if pmi.IridescenceTexture != nil {
-		metadata["iridescenceTexture"] = w.AddTexture(*pmi.IridescenceTexture)
+		metadata["iridescenceTexture"] = w.AddTexture(pmi.IridescenceTexture)
 	}
 
 	if pmi.IridescenceIor != nil {
@@ -360,7 +360,7 @@ func (pmi PolyformIridescence) ToMaterialExtensionData(w *Writer) map[string]any
 	}
 
 	if pmi.IridescenceThicknessTexture != nil {
-		metadata["iridescenceThicknessTexture"] = w.AddTexture(*pmi.IridescenceThicknessTexture)
+		metadata["iridescenceThicknessTexture"] = w.AddTexture(pmi.IridescenceThicknessTexture)
 	}
 
 	return metadata
@@ -397,13 +397,13 @@ func (ps PolyformSheen) ToMaterialExtensionData(w *Writer) map[string]any {
 	}
 
 	if ps.SheenColorTexture != nil {
-		metadata["sheenColorTexture"] = w.AddTexture(*ps.SheenColorTexture)
+		metadata["sheenColorTexture"] = w.AddTexture(ps.SheenColorTexture)
 	}
 
 	metadata["sheenRoughnessFactor"] = ps.SheenRoughnessFactor
 
 	if ps.SheenRoughnessTexture != nil {
-		metadata["sheenRoughnessTexture"] = w.AddTexture(*ps.SheenRoughnessTexture)
+		metadata["sheenRoughnessTexture"] = w.AddTexture(ps.SheenRoughnessTexture)
 	}
 
 	return metadata
@@ -441,7 +441,7 @@ func (pa PolyformAnisotropy) ToMaterialExtensionData(w *Writer) map[string]any {
 	metadata["anisotropyRotation"] = pa.AnisotropyRotation
 
 	if pa.AnisotropyTexture != nil {
-		metadata["anisotropyTexture"] = w.AddTexture(*pa.AnisotropyTexture)
+		metadata["anisotropyTexture"] = w.AddTexture(pa.AnisotropyTexture)
 	}
 
 	return metadata

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -154,9 +154,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 			extension: gltf.PolyformPbrSpecularGlossiness{
 				DiffuseFactor:             color.Black,
 				SpecularFactor:            color.White,
-				DiffuseTexture:            &gltf.PolyformTexture{URI: "DiffuseTexture.png"},
+				DiffuseTexture:            &gltf.PolyformTexture{},
 				GlossinessFactor:          pointer(.5),
-				SpecularGlossinessTexture: &gltf.PolyformTexture{URI: "SpecularGlossinessTexture.png"},
+				SpecularGlossinessTexture: &gltf.PolyformTexture{},
 			},
 			want: map[string]any{
 				"diffuseFactor":    [4]float64{0., 0., 0., 1.},
@@ -238,11 +238,11 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Iridescence/everything": {
 			extension: gltf.PolyformIridescence{
 				IridescenceFactor:           1,
-				IridescenceTexture:          &gltf.PolyformTexture{URI: "IridescenceTexture.png"},
+				IridescenceTexture:          &gltf.PolyformTexture{},
 				IridescenceIor:              pointer(1.),
 				IridescenceThicknessMinimum: pointer(1.),
 				IridescenceThicknessMaximum: pointer(1.),
-				IridescenceThicknessTexture: &gltf.PolyformTexture{URI: "IridescenceThicknessTexture.png"},
+				IridescenceThicknessTexture: &gltf.PolyformTexture{},
 			},
 			want: map[string]any{
 				"iridescenceFactor":           1.,
@@ -289,8 +289,8 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Sheen/everything": {
 			extension: gltf.PolyformSheen{
 				SheenRoughnessFactor:  1,
-				SheenRoughnessTexture: &gltf.PolyformTexture{URI: "SheenRoughnessTexture.png"},
-				SheenColorTexture:     &gltf.PolyformTexture{URI: "SheenColorTexture.png"},
+				SheenRoughnessTexture: &gltf.PolyformTexture{},
+				SheenColorTexture:     &gltf.PolyformTexture{},
 				SheenColorFactor:      color.White,
 			},
 			want: map[string]any{
@@ -447,9 +447,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Specular/everything": {
 			extension: gltf.PolyformSpecular{
 				Factor:       pointer(1.),
-				Texture:      &gltf.PolyformTexture{URI: "Texture.png"},
+				Texture:      &gltf.PolyformTexture{},
 				ColorFactor:  color.White,
-				ColorTexture: &gltf.PolyformTexture{URI: "ColorTexture.png"},
+				ColorTexture: &gltf.PolyformTexture{},
 			},
 			want: map[string]any{
 				"specularFactor":       1.0,

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -1,6 +1,8 @@
 package gltf_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"image/color"
 	"testing"
 
@@ -289,8 +291,8 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Sheen/everything": {
 			extension: gltf.PolyformSheen{
 				SheenRoughnessFactor:  1,
-				SheenRoughnessTexture: &gltf.PolyformTexture{},
-				SheenColorTexture:     &gltf.PolyformTexture{},
+				SheenRoughnessTexture: &gltf.PolyformTexture{URI: "SheenRoughnessTexture.png"},
+				SheenColorTexture:     &gltf.PolyformTexture{URI: "SheenColorTexture.png"},
 				SheenColorFactor:      color.White,
 			},
 			want: map[string]any{
@@ -469,8 +471,15 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 				return
 			}
 
+			buf := bytes.Buffer{}
+
+			outline := writer.ToGLTF(gltf.BufferEmbeddingStrategy_Base64Encode)
+			bolB, _ := json.MarshalIndent(outline, "", "    ")
+			buf.Write(bolB)
+			println(buf.String())
+
 			for k, v := range tc.want {
-				assert.Equal(t, v, data[k])
+				assert.Equal(t, v, data[k], "key %s not matching", k)
 			}
 		})
 	}

--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -1,8 +1,6 @@
 package gltf_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"image/color"
 	"testing"
 
@@ -156,9 +154,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 			extension: gltf.PolyformPbrSpecularGlossiness{
 				DiffuseFactor:             color.Black,
 				SpecularFactor:            color.White,
-				DiffuseTexture:            &gltf.PolyformTexture{},
+				DiffuseTexture:            &gltf.PolyformTexture{URI: "DiffuseTexture.png"},
 				GlossinessFactor:          pointer(.5),
-				SpecularGlossinessTexture: &gltf.PolyformTexture{},
+				SpecularGlossinessTexture: &gltf.PolyformTexture{URI: "SpecularGlossinessTexture.png"},
 			},
 			want: map[string]any{
 				"diffuseFactor":    [4]float64{0., 0., 0., 1.},
@@ -240,11 +238,11 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Iridescence/everything": {
 			extension: gltf.PolyformIridescence{
 				IridescenceFactor:           1,
-				IridescenceTexture:          &gltf.PolyformTexture{},
+				IridescenceTexture:          &gltf.PolyformTexture{URI: "IridescenceTexture.png"},
 				IridescenceIor:              pointer(1.),
 				IridescenceThicknessMinimum: pointer(1.),
 				IridescenceThicknessMaximum: pointer(1.),
-				IridescenceThicknessTexture: &gltf.PolyformTexture{},
+				IridescenceThicknessTexture: &gltf.PolyformTexture{URI: "IridescenceThicknessTexture.png"},
 			},
 			want: map[string]any{
 				"iridescenceFactor":           1.,
@@ -449,9 +447,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Specular/everything": {
 			extension: gltf.PolyformSpecular{
 				Factor:       pointer(1.),
-				Texture:      &gltf.PolyformTexture{},
+				Texture:      &gltf.PolyformTexture{URI: "Texture.png"},
 				ColorFactor:  color.White,
-				ColorTexture: &gltf.PolyformTexture{},
+				ColorTexture: &gltf.PolyformTexture{URI: "ColorTexture.png"},
 			},
 			want: map[string]any{
 				"specularFactor":       1.0,
@@ -470,13 +468,6 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 			if !assert.Len(t, data, len(tc.want)) {
 				return
 			}
-
-			buf := bytes.Buffer{}
-
-			outline := writer.ToGLTF(gltf.BufferEmbeddingStrategy_Base64Encode)
-			bolB, _ := json.MarshalIndent(outline, "", "    ")
-			buf.Write(bolB)
-			println(buf.String())
 
 			for k, v := range tc.want {
 				assert.Equal(t, v, data[k], "key %s not matching", k)

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -54,7 +54,7 @@ type PolyformPbrMetallicRoughness struct {
 }
 
 type PolyformNormal struct {
-	PolyformTexture
+	*PolyformTexture
 	Scale *float64
 }
 
@@ -125,7 +125,7 @@ func (pt *PolyformTexture) equal(other *PolyformTexture) bool {
 }
 
 func (pt *PolyformNormal) equal(other *PolyformNormal) bool {
-	if !pt.PolyformTexture.equal(&other.PolyformTexture) {
+	if !pt.PolyformTexture.equal(other.PolyformTexture) {
 		return false
 	}
 	return float64PtrsEqual(pt.Scale, other.Scale)

--- a/formats/gltf/model_trackers.go
+++ b/formats/gltf/model_trackers.go
@@ -32,3 +32,9 @@ type meshEntry struct {
 
 // materialIndices handle deduplication of GLTF materials
 type meshIndices map[meshEntry]int
+
+// samplerIndices handle deduplication of texture samplers
+type samplerIndices map[*Sampler]int
+
+// textureIndices handle deduplication of textures
+type textureIndices map[*PolyformTexture]int

--- a/formats/gltf/write.go
+++ b/formats/gltf/write.go
@@ -60,10 +60,6 @@ func ptrI(i int) *int {
 	return &i
 }
 
-func ptrIEqual(i, j *int) bool {
-	return (i == nil && j == nil) || (i != nil && j != nil && *i == *j)
-}
-
 func flattenSkeletonToNodes(offset int, skeleton animation.Skeleton, out *bytes.Buffer) []Node {
 	nodes := make([]Node, 0)
 

--- a/formats/gltf/write.go
+++ b/formats/gltf/write.go
@@ -60,6 +60,10 @@ func ptrI(i int) *int {
 	return &i
 }
 
+func ptrIEqual(i, j *int) bool {
+	return (i == nil && j == nil) || (i != nil && j != nil && *i == *j)
+}
+
 func flattenSkeletonToNodes(offset int, skeleton animation.Skeleton, out *bytes.Buffer) []Node {
 	nodes := make([]Node, 0)
 

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -483,7 +483,7 @@ func TestWrite_TexturedTriWithMaterialWithColor(t *testing.T) {
 }`, buf.String())
 }
 
-func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleTexDedupe(t *testing.T) {
+func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleDedupe(t *testing.T) {
 	// ARRANGE ================================================================
 	tri1 := modeling.NewTriangleMesh([]int{0, 1, 2}).
 		SetFloat3Attribute(
@@ -540,6 +540,12 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleTexDedupe(t *testing.
 
 	// ACT ====================================================================
 	roughness := 0.
+	sampler := &gltf.Sampler{
+		WrapS:     gltf.SamplerWrap_REPEAT,
+		WrapT:     gltf.SamplerWrap_REPEAT,
+		MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+		MagFilter: gltf.SamplerMagFilter_LINEAR,
+	}
 	err := gltf.WriteText(gltf.PolyformScene{
 		Models: []gltf.PolyformModel{
 			{
@@ -551,13 +557,8 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleTexDedupe(t *testing.
 						BaseColorFactor: color.RGBA{255, 100, 80, 255},
 						RoughnessFactor: &roughness,
 						BaseColorTexture: &gltf.PolyformTexture{
-							URI: "this_is_a_test.png",
-							Sampler: &gltf.Sampler{
-								WrapS:     gltf.SamplerWrap_REPEAT,
-								WrapT:     gltf.SamplerWrap_REPEAT,
-								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
-								MagFilter: gltf.SamplerMagFilter_LINEAR,
-							},
+							URI:     "this_is_a_test.png",
+							Sampler: sampler,
 						},
 					},
 				},
@@ -571,14 +572,379 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleTexDedupe(t *testing.
 						BaseColorFactor: color.RGBA{255, 100, 80, 255},
 						RoughnessFactor: &roughness,
 						BaseColorTexture: &gltf.PolyformTexture{
-							URI: "this_is_a_test.png",
-							Sampler: &gltf.Sampler{
-								WrapS:     gltf.SamplerWrap_REPEAT,
-								WrapT:     gltf.SamplerWrap_REPEAT,
-								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
-								MagFilter: gltf.SamplerMagFilter_LINEAR,
-							},
+							URI:     "this_is_a_test.png",
+							Sampler: sampler,
 						},
+					},
+				},
+			},
+		},
+	}, &buf)
+
+	// ASSERT =================================================================
+	assert.NoError(t, err)
+	assert.Equal(t, `{
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        },
+        {
+            "bufferView": 4,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 5,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 6,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 7,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        }
+    ],
+    "asset": {
+        "version": "2.0",
+        "generator": "https://github.com/EliCDavis/polyform"
+    },
+    "buffers": [
+        {
+            "byteLength": 204,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 72,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 96,
+            "byteLength": 6,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 102,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 138,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 174,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 198,
+            "byteLength": 6,
+            "target": 34963
+        }
+    ],
+    "images": [
+        {
+            "uri": "this_is_a_test.png"
+        }
+    ],
+    "materials": [
+        {
+            "name": "My Material1",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "baseColorTexture": {
+                    "index": 0
+                },
+                "roughnessFactor": 0
+            }
+        },
+        {
+            "name": "My Material2",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "baseColorTexture": {
+                    "index": 1
+                },
+                "roughnessFactor": 0
+            }
+        }
+    ],
+    "meshes": [
+        {
+            "name": "mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 0,
+                        "POSITION": 1,
+                        "TEXCOORD_0": 2
+                    },
+                    "indices": 3,
+                    "material": 0
+                }
+            ]
+        },
+        {
+            "name": "mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 4,
+                        "POSITION": 5,
+                        "TEXCOORD_0": 6
+                    },
+                    "indices": 7,
+                    "material": 1
+                }
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0,
+            "name": "mesh"
+        },
+        {
+            "mesh": 1,
+            "name": "mesh"
+        }
+    ],
+    "samplers": [
+        {
+            "magFilter": 9729,
+            "minFilter": 9987,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    ],
+    "scenes": [
+        {
+            "nodes": [
+                0,
+                1
+            ]
+        }
+    ],
+    "textures": [
+        {
+            "sampler": 0,
+            "source": 0
+        },
+        {
+            "sampler": 0,
+            "source": 0
+        }
+    ]
+}`, buf.String())
+}
+
+func TestWrite_TexturedTriWithMaterialWithColor_TextureDedupe(t *testing.T) {
+	// ARRANGE ================================================================
+	tri1 := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+	tri2 := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+
+	buf := bytes.Buffer{}
+
+	// ACT ====================================================================
+	roughness := 0.
+	texture := &gltf.PolyformTexture{
+		URI: "this_is_a_test.png",
+		Sampler: &gltf.Sampler{
+			WrapS:     gltf.SamplerWrap_REPEAT,
+			WrapT:     gltf.SamplerWrap_REPEAT,
+			MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+			MagFilter: gltf.SamplerMagFilter_LINEAR,
+		},
+	}
+
+	err := gltf.WriteText(gltf.PolyformScene{
+		Models: []gltf.PolyformModel{
+			{
+				Name: "mesh",
+				Mesh: &tri1,
+				Material: &gltf.PolyformMaterial{
+					Name: "My Material1",
+					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+						BaseColorFactor:  color.RGBA{255, 100, 80, 255},
+						RoughnessFactor:  &roughness,
+						BaseColorTexture: texture,
+					},
+				},
+			},
+			{
+				Name: "mesh",
+				Mesh: &tri2,
+				Material: &gltf.PolyformMaterial{
+					Name: "My Material2",
+					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+						BaseColorFactor:  color.RGBA{255, 100, 80, 255},
+						RoughnessFactor:  &roughness,
+						BaseColorTexture: texture,
 					},
 				},
 			},

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -306,17 +306,9 @@ func TestWrite_TexturedTriWithMaterialWithColor(t *testing.T) {
 				Material: &gltf.PolyformMaterial{
 					Name: "My Material",
 					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
-						BaseColorFactor: color.RGBA{255, 100, 80, 255},
-						RoughnessFactor: &roughness,
-						BaseColorTexture: &gltf.PolyformTexture{
-							URI: "this_is_a_test.png",
-							Sampler: &gltf.Sampler{
-								WrapS:     gltf.SamplerWrap_REPEAT,
-								WrapT:     gltf.SamplerWrap_REPEAT,
-								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
-								MagFilter: gltf.SamplerMagFilter_LINEAR,
-							},
-						},
+						BaseColorFactor:  color.RGBA{255, 100, 80, 255},
+						RoughnessFactor:  &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{URI: "this_is_a_test.png"},
 					},
 				},
 			},
@@ -459,14 +451,6 @@ func TestWrite_TexturedTriWithMaterialWithColor(t *testing.T) {
             "name": "mesh"
         }
     ],
-    "samplers": [
-        {
-            "magFilter": 9729,
-            "minFilter": 9987,
-            "wrapS": 10497,
-            "wrapT": 10497
-        }
-    ],
     "scenes": [
         {
             "nodes": [
@@ -476,7 +460,6 @@ func TestWrite_TexturedTriWithMaterialWithColor(t *testing.T) {
     ],
     "textures": [
         {
-            "sampler": 0,
             "source": 0
         }
     ]

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -483,6 +483,378 @@ func TestWrite_TexturedTriWithMaterialWithColor(t *testing.T) {
 }`, buf.String())
 }
 
+func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleTexDedupe(t *testing.T) {
+	// ARRANGE ================================================================
+	tri1 := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+	tri2 := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		).
+		SetFloat3Attribute(
+			modeling.NormalAttribute,
+			[]vector3.Float64{
+				vector3.New(1., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(0., 0., 1.),
+			},
+		).
+		SetFloat2Attribute(
+			modeling.TexCoordAttribute,
+			[]vector2.Float64{
+				vector2.New(0., 0.),
+				vector2.New(0., 1.),
+				vector2.New(1., 0.),
+			},
+		)
+
+	buf := bytes.Buffer{}
+
+	// ACT ====================================================================
+	roughness := 0.
+	err := gltf.WriteText(gltf.PolyformScene{
+		Models: []gltf.PolyformModel{
+			{
+				Name: "mesh",
+				Mesh: &tri1,
+				Material: &gltf.PolyformMaterial{
+					Name: "My Material1",
+					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+						BaseColorFactor: color.RGBA{255, 100, 80, 255},
+						RoughnessFactor: &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{
+							URI: "this_is_a_test.png",
+							Sampler: &gltf.Sampler{
+								WrapS:     gltf.SamplerWrap_REPEAT,
+								WrapT:     gltf.SamplerWrap_REPEAT,
+								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+								MagFilter: gltf.SamplerMagFilter_LINEAR,
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "mesh",
+				Mesh: &tri2,
+				Material: &gltf.PolyformMaterial{
+					Name: "My Material2",
+					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+						BaseColorFactor: color.RGBA{255, 100, 80, 255},
+						RoughnessFactor: &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{
+							URI: "this_is_a_test.png",
+							Sampler: &gltf.Sampler{
+								WrapS:     gltf.SamplerWrap_REPEAT,
+								WrapT:     gltf.SamplerWrap_REPEAT,
+								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+								MagFilter: gltf.SamplerMagFilter_LINEAR,
+							},
+						},
+					},
+				},
+			},
+		},
+	}, &buf)
+
+	// ASSERT =================================================================
+	assert.NoError(t, err)
+	assert.Equal(t, `{
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        },
+        {
+            "bufferView": 4,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 5,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 6,
+            "componentType": 5126,
+            "type": "VEC2",
+            "count": 3,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 7,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        }
+    ],
+    "asset": {
+        "version": "2.0",
+        "generator": "https://github.com/EliCDavis/polyform"
+    },
+    "buffers": [
+        {
+            "byteLength": 204,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 72,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 96,
+            "byteLength": 6,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 102,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 138,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 174,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 198,
+            "byteLength": 6,
+            "target": 34963
+        }
+    ],
+    "images": [
+        {
+            "uri": "this_is_a_test.png"
+        }
+    ],
+    "materials": [
+        {
+            "name": "My Material1",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "baseColorTexture": {
+                    "index": 0
+                },
+                "roughnessFactor": 0
+            }
+        },
+        {
+            "name": "My Material2",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "baseColorTexture": {
+                    "index": 0
+                },
+                "roughnessFactor": 0
+            }
+        }
+    ],
+    "meshes": [
+        {
+            "name": "mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 0,
+                        "POSITION": 1,
+                        "TEXCOORD_0": 2
+                    },
+                    "indices": 3,
+                    "material": 0
+                }
+            ]
+        },
+        {
+            "name": "mesh",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": 4,
+                        "POSITION": 5,
+                        "TEXCOORD_0": 6
+                    },
+                    "indices": 7,
+                    "material": 1
+                }
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0,
+            "name": "mesh"
+        },
+        {
+            "mesh": 1,
+            "name": "mesh"
+        }
+    ],
+    "samplers": [
+        {
+            "magFilter": 9729,
+            "minFilter": 9987,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    ],
+    "scenes": [
+        {
+            "nodes": [
+                0,
+                1
+            ]
+        }
+    ],
+    "textures": [
+        {
+            "sampler": 0,
+            "source": 0
+        }
+    ]
+}`, buf.String())
+}
+
 func TestWrite_TexturedTriWithTexExtension(t *testing.T) {
 	// ARRANGE ================================================================
 	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).

--- a/formats/gltf/writer.go
+++ b/formats/gltf/writer.go
@@ -567,7 +567,7 @@ func (w *Writer) AddTexture(polyTex PolyformTexture) *TextureInfo {
 	var texFound bool
 texCompare:
 	for i, tex := range w.textures {
-		if !ptrIEqual(tex.Source, newTex.Source) && !ptrIEqual(tex.Sampler, newTex.Sampler) {
+		if !ptrIEqual(tex.Source, newTex.Source) || !ptrIEqual(tex.Sampler, newTex.Sampler) {
 			continue
 		}
 		if len(tex.Extensions) != len(newTex.Extensions) {


### PR DESCRIPTION
This PR adds logic to `writer.AddTexture()` method to check and reuse existing resources if they are identical to newly added, instead of adding more.

Images are compared by URIs only, since byte buffer embedding is not supported yet.
Samplers are compared by four numeric values they have.
Textures are compared by source (image) and sampler indices, and by the extensions map. 

`ChildOfRootProperty` values are not checked for any objects.

---
This change of behaviour required minor changes in the extension tests - the textures in the extensions now need to be _actually_ different so they are given different indices. An empty texture is identical to any other empty texture, so I made them non-empty.