### PR TITLE
Re-add tex deduplication by value

### DIFF
--- a/formats/gltf/extensions_test.go
+++ b/formats/gltf/extensions_test.go
@@ -154,9 +154,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 			extension: gltf.PolyformPbrSpecularGlossiness{
 				DiffuseFactor:             color.Black,
 				SpecularFactor:            color.White,
-				DiffuseTexture:            &gltf.PolyformTexture{},
+				DiffuseTexture:            &gltf.PolyformTexture{URI: "DiffuseTexture.png"},
 				GlossinessFactor:          pointer(.5),
-				SpecularGlossinessTexture: &gltf.PolyformTexture{},
+				SpecularGlossinessTexture: &gltf.PolyformTexture{URI: "SpecularGlossinessTexture.png"},
 			},
 			want: map[string]any{
 				"diffuseFactor":    [4]float64{0., 0., 0., 1.},
@@ -238,11 +238,11 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Iridescence/everything": {
 			extension: gltf.PolyformIridescence{
 				IridescenceFactor:           1,
-				IridescenceTexture:          &gltf.PolyformTexture{},
+				IridescenceTexture:          &gltf.PolyformTexture{URI: "IridescenceTexture.png"},
 				IridescenceIor:              pointer(1.),
 				IridescenceThicknessMinimum: pointer(1.),
 				IridescenceThicknessMaximum: pointer(1.),
-				IridescenceThicknessTexture: &gltf.PolyformTexture{},
+				IridescenceThicknessTexture: &gltf.PolyformTexture{URI: "IridescenceThicknessTexture.png"},
 			},
 			want: map[string]any{
 				"iridescenceFactor":           1.,
@@ -289,8 +289,8 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Sheen/everything": {
 			extension: gltf.PolyformSheen{
 				SheenRoughnessFactor:  1,
-				SheenRoughnessTexture: &gltf.PolyformTexture{},
-				SheenColorTexture:     &gltf.PolyformTexture{},
+				SheenRoughnessTexture: &gltf.PolyformTexture{URI: "SheenRoughnessTexture.png"},
+				SheenColorTexture:     &gltf.PolyformTexture{URI: "SheenColorTexture.png"},
 				SheenColorFactor:      color.White,
 			},
 			want: map[string]any{
@@ -447,9 +447,9 @@ func TestMaterialExtension_ToExtensionData(t *testing.T) {
 		"Specular/everything": {
 			extension: gltf.PolyformSpecular{
 				Factor:       pointer(1.),
-				Texture:      &gltf.PolyformTexture{},
+				Texture:      &gltf.PolyformTexture{URI: "Texture.png"},
 				ColorFactor:  color.White,
-				ColorTexture: &gltf.PolyformTexture{},
+				ColorTexture: &gltf.PolyformTexture{URI: "ColorTexture.png"},
 			},
 			want: map[string]any{
 				"specularFactor":       1.0,

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -70,6 +70,35 @@ type PolyformTexture struct {
 	Extensions []TextureExtension
 }
 
+func (pm *PolyformTexture) prepareExtensions(w *Writer) (map[string]any, map[string]any) {
+	var texInfoExt map[string]any
+	var texExt map[string]any
+
+	for _, ext := range pm.Extensions {
+		id := ext.ExtensionID()
+		if ext.IsInfo() {
+			if texInfoExt == nil {
+				texInfoExt = make(map[string]any)
+			}
+
+			texInfoExt[id] = ext.ToTextureExtensionData(w)
+		} else {
+			if texExt == nil {
+				texExt = make(map[string]any)
+			}
+
+			texExt[id] = ext.ToTextureExtensionData(w)
+		}
+
+		w.extensionsUsed[id] = true
+		if ext.IsRequired() {
+			w.extensionsRequired[id] = true
+		}
+	}
+
+	return texExt, texInfoExt
+}
+
 func (pm *PolyformMaterial) equal(other *PolyformMaterial) bool {
 	if pm == other {
 		return true

--- a/formats/gltf/model_trackers.go
+++ b/formats/gltf/model_trackers.go
@@ -33,8 +33,5 @@ type meshEntry struct {
 // materialIndices handle deduplication of GLTF materials
 type meshIndices map[meshEntry]int
 
-// samplerIndices handle deduplication of texture samplers
-type samplerIndices map[*Sampler]int
-
 // textureIndices handle deduplication of textures
 type textureIndices map[*PolyformTexture]int

--- a/formats/gltf/sampler.go
+++ b/formats/gltf/sampler.go
@@ -35,3 +35,24 @@ type Sampler struct {
 	WrapS     SamplerWrap      `json:"wrapS,omitempty"`     // S (U) wrapping mode.  All valid values correspond to WebGL enums.
 	WrapT     SamplerWrap      `json:"wrapT,omitempty"`     // T (V) wrapping mode.
 }
+
+func (s *Sampler) equal(other *Sampler) bool {
+	if s == other { // Either both nil or point to the same object
+		return true
+	}
+
+	if s == nil || other == nil { // only one can be nil at this point
+		return false
+	}
+
+	if s.MagFilter != other.MagFilter || s.MinFilter != other.MinFilter ||
+		s.WrapS != other.WrapS || s.WrapT != other.WrapT {
+		return false
+	}
+
+	if !s.ChildOfRootProperty.equal(other.ChildOfRootProperty) {
+		return false
+	}
+
+	return true
+}

--- a/formats/gltf/structure.go
+++ b/formats/gltf/structure.go
@@ -27,6 +27,26 @@ type ChildOfRootProperty struct {
 	Name string `json:"name,omitempty"`
 }
 
+func (s ChildOfRootProperty) equal(other ChildOfRootProperty) bool {
+	if s.Name != other.Name || len(s.Extensions) != len(other.Extensions) || len(s.Extras) != len(other.Extras) {
+		return false
+	}
+
+	for key, val := range s.Extensions {
+		if other.Extensions[key] != val {
+			return false
+		}
+	}
+
+	for key, val := range s.Extras {
+		if other.Extras[key] != val {
+			return false
+		}
+	}
+
+	return true
+}
+
 // The root nodes of a scene.
 // https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/scene.schema.json
 type Scene struct {
@@ -143,4 +163,25 @@ type Gltf struct {
 	Scenes      []Scene      `json:"scenes,omitempty"`      // An array of scenes.
 	Skins       []Skin       `json:"skins,omitempty"`       // An array of skins.  A skin is defined by joints and matrices.
 	Textures    []Texture    `json:"textures,omitempty"`    // An array of textures
+}
+
+func (t Texture) equal(other Texture) bool {
+	if !ptrIEqual(t.Source, other.Source) || !ptrIEqual(t.Sampler, other.Sampler) {
+		return false
+	}
+	if len(t.Extensions) != len(other.Extensions) {
+		return false
+	}
+
+	for key, val := range t.Extensions {
+		if other.Extensions[key] != val {
+			return false
+		}
+	}
+
+	if !t.ChildOfRootProperty.equal(other.ChildOfRootProperty) {
+		return false
+	}
+
+	return true
 }

--- a/formats/gltf/structure.go
+++ b/formats/gltf/structure.go
@@ -33,13 +33,15 @@ func (s ChildOfRootProperty) equal(other ChildOfRootProperty) bool {
 	}
 
 	for key, val := range s.Extensions {
-		if other.Extensions[key] != val {
+		otherVal, exists := other.Extensions[key]
+		if !exists || otherVal != val {
 			return false
 		}
 	}
 
 	for key, val := range s.Extras {
-		if other.Extras[key] != val {
+		otherVal, exists := other.Extras[key]
+		if !exists || otherVal != val {
 			return false
 		}
 	}
@@ -174,7 +176,8 @@ func (t Texture) equal(other Texture) bool {
 	}
 
 	for key, val := range t.Extensions {
-		if other.Extensions[key] != val {
+		otherVal, exists := other.Extensions[key]
+		if !exists || otherVal != val {
 			return false
 		}
 	}

--- a/formats/gltf/write.go
+++ b/formats/gltf/write.go
@@ -60,6 +60,10 @@ func ptrI(i int) *int {
 	return &i
 }
 
+func ptrIEqual(i, j *int) bool {
+	return (i == nil && j == nil) || (i != nil && j != nil && *i == *j)
+}
+
 func flattenSkeletonToNodes(offset int, skeleton animation.Skeleton, out *bytes.Buffer) []Node {
 	nodes := make([]Node, 0)
 

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -15,6 +15,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockTextureExtension struct{}
+
+func (m mockTextureExtension) ExtensionID() string {
+	return "mocXtension"
+}
+func (m mockTextureExtension) ToTextureExtensionData(w *gltf.Writer) map[string]any {
+	return nil
+}
+func (m mockTextureExtension) IsRequired() bool {
+	return false
+}
+func (m mockTextureExtension) IsInfo() bool {
+	return false
+}
+
 func TestWriteBasicTri(t *testing.T) {
 	// ARRANGE ================================================================
 	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).
@@ -555,8 +570,9 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleDedupe(t *testing.T) 
 						BaseColorFactor: color.RGBA{255, 100, 80, 255},
 						RoughnessFactor: &roughness,
 						BaseColorTexture: &gltf.PolyformTexture{
-							URI:     "this_is_a_test.png",
-							Sampler: sampler,
+							URI:        "this_is_a_test.png",
+							Sampler:    sampler,
+							Extensions: []gltf.TextureExtension{&mockTextureExtension{}},
 						},
 					},
 				},
@@ -567,6 +583,9 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleDedupe(t *testing.T) 
 	// ASSERT =================================================================
 	assert.NoError(t, err)
 	assert.Equal(t, `{
+    "extensionsUsed": [
+        "mocXtension"
+    ],
     "accessors": [
         {
             "bufferView": 0,
@@ -832,13 +851,16 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleDedupe(t *testing.T) 
         },
         {
             "sampler": 0,
-            "source": 0
+            "source": 0,
+            "extensions": {
+                "mocXtension": null
+            }
         }
     ]
 }`, buf.String())
 }
 
-func TestWrite_TexturedTriWithMaterialWithColor_TextureDedupe(t *testing.T) {
+func TestWrite_TexturedTriWithMaterialWithColor_TextureValueDedupe(t *testing.T) {
 	// ARRANGE ================================================================
 	tri1 := modeling.NewTriangleMesh([]int{0, 1, 2}).
 		SetFloat3Attribute(
@@ -895,16 +917,6 @@ func TestWrite_TexturedTriWithMaterialWithColor_TextureDedupe(t *testing.T) {
 
 	// ACT ====================================================================
 	roughness := 0.
-	texture := &gltf.PolyformTexture{
-		URI: "this_is_a_test.png",
-		Sampler: &gltf.Sampler{
-			WrapS:     gltf.SamplerWrap_REPEAT,
-			WrapT:     gltf.SamplerWrap_REPEAT,
-			MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
-			MagFilter: gltf.SamplerMagFilter_LINEAR,
-		},
-	}
-
 	err := gltf.WriteText(gltf.PolyformScene{
 		Models: []gltf.PolyformModel{
 			{
@@ -913,9 +925,17 @@ func TestWrite_TexturedTriWithMaterialWithColor_TextureDedupe(t *testing.T) {
 				Material: &gltf.PolyformMaterial{
 					Name: "My Material1",
 					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
-						BaseColorFactor:  color.RGBA{255, 100, 80, 255},
-						RoughnessFactor:  &roughness,
-						BaseColorTexture: texture,
+						BaseColorFactor: color.RGBA{255, 100, 80, 255},
+						RoughnessFactor: &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{
+							URI: "this_is_a_test.png",
+							Sampler: &gltf.Sampler{
+								WrapS:     gltf.SamplerWrap_REPEAT,
+								WrapT:     gltf.SamplerWrap_REPEAT,
+								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+								MagFilter: gltf.SamplerMagFilter_LINEAR,
+							},
+						},
 					},
 				},
 			},
@@ -925,9 +945,17 @@ func TestWrite_TexturedTriWithMaterialWithColor_TextureDedupe(t *testing.T) {
 				Material: &gltf.PolyformMaterial{
 					Name: "My Material2",
 					PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
-						BaseColorFactor:  color.RGBA{255, 100, 80, 255},
-						RoughnessFactor:  &roughness,
-						BaseColorTexture: texture,
+						BaseColorFactor: color.RGBA{255, 100, 80, 255},
+						RoughnessFactor: &roughness,
+						BaseColorTexture: &gltf.PolyformTexture{
+							URI: "this_is_a_test.png",
+							Sampler: &gltf.Sampler{
+								WrapS:     gltf.SamplerWrap_REPEAT,
+								WrapT:     gltf.SamplerWrap_REPEAT,
+								MinFilter: gltf.SamplerMinFilter_LINEAR_MIPMAP_LINEAR,
+								MagFilter: gltf.SamplerMagFilter_LINEAR,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
I think converting texture deduplication to pointer-comparison pattern was a mistake.

Effectively, that pattern forced the real value deduplication onto the client, which is what I discovered when I tried to use the latest build of the library.

---
I think this using pointers is a wrong approach in principle. This approach actually means no real deduplication within the library, because if the pointers are pointing to the same object - deduplication was already done by the client. So the heavy lifting was done, and the all that library is doing is not screwing it all up, which is not an achievement.

I think the library should in fact do this heavy lifting and do real deduplication - compare objects by values and reuse the same object indexes in GLTF if the values are the same, even if the actual instances in memory are different.

With meshes the approach was different purely because of technical limitations - comparing large meshes directly by vector attribute values is prohibitively expensive. So that was pushed onto the client where the logic and metadata around the scene creation allow to avoid direct comparisons.

For all other objects - comparison is not technically difficult and should be done by the library. 

---
I've kept pointer comparison as well as a shortcut, since it's already implemented and the API adjusted to support it - it's not worth rolling back. But I've added value-based deduplication alongside, and distributed comparison logic into appropriate `equal()` helper methods.