### PR TITLE
feat: add polyform to flake packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cert.pem
 key.pem
 
 # nix
+result
 /result/
 /result-.*/
 


### PR DESCRIPTION
### Summary
- Re-works the flake outputs so that `polyform` and all programs under the `examples` directory can be run with the `nix run` command interface.
- Formats the flake with `nix run nixpkgs#nixfmt -- ./flake.nix`

### Description

The `polyform` command, as well as each example in the examples directory, can now be run with:
```
# Add a set of dashes to pass flags to the target polyform command and not the nix command
nix run .#polyform -- --help
nix run .#examples.mesh-util -- --help
```

The flake outputs for the examples now expose the cross-built packages:
```
# Outputs to 'result/bin/darwin_amd64/mesh-util'
nix build .#examples.darwin.amd64.mesh-util

# Outputs to 'result/bin/windows_amd64/mesh-util.exe'
nix build .#examples.windows.amd64.mesh-util
```