### PR TITLE
Integrate mesh deduplication and GPU instancing handling

### DIFF
--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -3,16 +3,20 @@ package gltf
 import (
 	"image/color"
 
-	"github.com/EliCDavis/polyform/math/quaternion"
 	"github.com/EliCDavis/polyform/math/trs"
 	"github.com/EliCDavis/polyform/modeling"
 	"github.com/EliCDavis/polyform/modeling/animation"
-	"github.com/EliCDavis/vector/vector3"
 )
 
 type PolyformScene struct {
 	Models []PolyformModel
 	Lights []KHR_LightsPunctual
+
+	// UseGpuInstancing indicates that the EXT_mesh_gpu_instancing extension should be used
+	// when appropriate for mesh instances. If not set, even explicit GPU instances will be serialized
+	// as individual nodes. If set and GPU instances are present, they will be serialized using
+	// the extension.
+	UseGpuInstancing bool
 }
 
 // PolyformModel is a utility structure for reading/writing to GLTF format within
@@ -22,21 +26,13 @@ type PolyformModel struct {
 	Mesh     *modeling.Mesh
 	Material *PolyformMaterial
 
-	Translation *vector3.Float64
-	Scale       *vector3.Float64
-	Rotation    *quaternion.Quaternion
-
-	// Utilizes the EXT_mesh_gpu_instancing extension to duplicate the model
-	// without increasing the mesh data footprint on the GPU
-	// deprecated
-	GpuInstances []trs.TRS
+	// TRS contains the transformation (translation, rotation, scale) for this model
+	TRS *trs.TRS
 
 	// Utilizes the EXT_mesh_gpu_instancing extension to duplicate the model
 	// without increasing the mesh data footprint on the GPU.
-	// If this flag is set - the TRS attributes are expected to be provided for the model.
-	// All model instances that share same mesh and material will be rendered in a single draw call
-	// using GPU instancing extension.
-	UseGpuInstancing bool
+	// This is a list of transformations where this model should be repeated.
+	GpuInstances []trs.TRS
 
 	Skeleton   *animation.Skeleton
 	Animations []animation.Sequence

--- a/formats/gltf/model.go
+++ b/formats/gltf/model.go
@@ -28,7 +28,15 @@ type PolyformModel struct {
 
 	// Utilizes the EXT_mesh_gpu_instancing extension to duplicate the model
 	// without increasing the mesh data footprint on the GPU
+	// deprecated
 	GpuInstances []trs.TRS
+
+	// Utilizes the EXT_mesh_gpu_instancing extension to duplicate the model
+	// without increasing the mesh data footprint on the GPU.
+	// If this flag is set - the TRS attributes are expected to be provided for the model.
+	// All model instances that share same mesh and material will be rendered in a single draw call
+	// using GPU instancing extension.
+	UseGpuInstancing bool
 
 	Skeleton   *animation.Skeleton
 	Animations []animation.Sequence

--- a/formats/gltf/model_trackers.go
+++ b/formats/gltf/model_trackers.go
@@ -1,6 +1,10 @@
 package gltf
 
-import "github.com/EliCDavis/polyform/modeling"
+import (
+	"github.com/EliCDavis/polyform/math/trs"
+	"github.com/EliCDavis/polyform/modeling"
+	"github.com/EliCDavis/polyform/modeling/animation"
+)
 
 // materialEntry tracks a unique material and its corresponding GLTF material index
 type materialEntry struct {
@@ -42,3 +46,67 @@ type writtenMeshData struct {
 }
 
 type attributeIndices map[*modeling.Mesh]writtenMeshData
+
+// modelInstance represents an instance of a model with specific transformation
+type modelInstance struct {
+	meshIndex int
+	name      string
+	trs       *trs.TRS // Holds the transformation data for this instance
+}
+
+// modelInstanceGroup contains instances of the same mesh that should be rendered together
+type modelInstanceGroup struct {
+	meshIndex  int
+	instances  []modelInstance
+	skeleton   *animation.Skeleton
+	animations []animation.Sequence
+}
+
+func (g modelInstanceGroup) isAnimated() bool {
+	return g.skeleton != nil || len(g.animations) > 0
+}
+
+// instanceTracker handles tracking and organizing model instances
+type instanceTracker struct {
+	groups []modelInstanceGroup
+}
+
+// findOrCreateGroup finds an existing group with matching mesh and material indices or creates a new one
+func (it *instanceTracker) findOrCreateGroup(meshIndex int, skeleton *animation.Skeleton, animations []animation.Sequence) *modelInstanceGroup {
+	// For models with skeletons or animations, we need to create a unique group
+	// because these can't be instanced with other models
+	hasAnimated := skeleton != nil || len(animations) > 0
+
+	if hasAnimated {
+		// Create a new unique group for this animated model
+		it.groups = append(it.groups, modelInstanceGroup{
+			meshIndex:  meshIndex,
+			instances:  make([]modelInstance, 0),
+			skeleton:   skeleton,
+			animations: animations,
+		})
+		return &it.groups[len(it.groups)-1]
+	}
+
+	// For standard models without animations, look for an existing group with the same mesh
+	for i := range it.groups {
+		g := &it.groups[i]
+		if g.meshIndex == meshIndex && !g.isAnimated() {
+			return g
+		}
+	}
+
+	// No existing group found, create a new one
+	it.groups = append(it.groups, modelInstanceGroup{
+		meshIndex: meshIndex,
+		instances: make([]modelInstance, 0),
+	})
+
+	return &it.groups[len(it.groups)-1]
+}
+
+// add adds a new instance to the appropriate group
+func (it *instanceTracker) add(meshIndex int, instance modelInstance, skeleton *animation.Skeleton, animations []animation.Sequence) {
+	group := it.findOrCreateGroup(meshIndex, skeleton, animations)
+	group.instances = append(group.instances, instance)
+}

--- a/formats/gltf/nodes.go
+++ b/formats/gltf/nodes.go
@@ -7,12 +7,10 @@ import (
 	"github.com/EliCDavis/polyform/drawing/coloring"
 	"github.com/EliCDavis/polyform/generator"
 	"github.com/EliCDavis/polyform/generator/artifact"
-	"github.com/EliCDavis/polyform/math/quaternion"
 	"github.com/EliCDavis/polyform/math/trs"
 	"github.com/EliCDavis/polyform/modeling"
 	"github.com/EliCDavis/polyform/nodes"
 	"github.com/EliCDavis/polyform/refutil"
-	"github.com/EliCDavis/vector/vector3"
 )
 
 func init() {
@@ -79,9 +77,7 @@ type ModelNodeData struct {
 	Mesh     nodes.Output[modeling.Mesh]
 	Material nodes.Output[PolyformMaterial]
 
-	Translation nodes.Output[vector3.Float64]
-	Rotation    nodes.Output[quaternion.Quaternion]
-	Scale       nodes.Output[vector3.Float64]
+	TRS nodes.Output[trs.TRS]
 
 	GpuInstances nodes.Output[[]trs.TRS]
 }
@@ -103,19 +99,9 @@ func (gmnd ModelNodeData) Out() nodes.StructOutput[PolyformModel] {
 		model.GpuInstances = gmnd.GpuInstances.Value()
 	}
 
-	if gmnd.Translation != nil {
-		v := gmnd.Translation.Value()
-		model.Translation = &v
-	}
-
-	if gmnd.Scale != nil {
-		v := gmnd.Scale.Value()
-		model.Scale = &v
-	}
-
-	if gmnd.Rotation != nil {
-		v := gmnd.Rotation.Value()
-		model.Rotation = &v
+	if gmnd.TRS != nil {
+		v := gmnd.TRS.Value()
+		model.TRS = &v
 	}
 
 	return nodes.NewStructOutput(model)

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -699,8 +699,8 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleDedupe(t *testing.T) 
     },
     "buffers": [
         {
-            "byteLength": 204,
-            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+            "byteLength": 206,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA/AACAPwAAAAAAAAEAAgA="
         }
     ],
     "bufferViews": [
@@ -729,25 +729,25 @@ func TestWrite_TexturedTriWithMaterialWithColor_ImageSampleDedupe(t *testing.T) 
         },
         {
             "buffer": 0,
-            "byteOffset": 102,
+            "byteOffset": 104,
             "byteLength": 36,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 138,
+            "byteOffset": 140,
             "byteLength": 36,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 174,
+            "byteOffset": 176,
             "byteLength": 24,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 198,
+            "byteOffset": 200,
             "byteLength": 6,
             "target": 34963
         }
@@ -1078,8 +1078,8 @@ func TestWrite_TexturedTriWithMaterialWithColor_TextureValueDedupe(t *testing.T)
     },
     "buffers": [
         {
-            "byteLength": 204,
-            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIA"
+            "byteLength": 206,
+            "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAABAAIAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA/AACAPwAAAAAAAAEAAgA="
         }
     ],
     "bufferViews": [
@@ -1108,25 +1108,25 @@ func TestWrite_TexturedTriWithMaterialWithColor_TextureValueDedupe(t *testing.T)
         },
         {
             "buffer": 0,
-            "byteOffset": 102,
+            "byteOffset": 104,
             "byteLength": 36,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 138,
+            "byteOffset": 140,
             "byteLength": 36,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 174,
+            "byteOffset": 176,
             "byteLength": 24,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 198,
+            "byteOffset": 200,
             "byteLength": 6,
             "target": 34963
         }
@@ -2342,8 +2342,8 @@ func TestWrite_MaterialsDeduplicated(t *testing.T) {
     },
     "buffers": [
         {
-            "byteLength": 84,
-            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAABAAIAAAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAABAAIA"
+            "byteLength": 86,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAABAAIAAAAAAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAIA/AAAAAAAAAAAAAAEAAgA="
         }
     ],
     "bufferViews": [
@@ -2360,13 +2360,13 @@ func TestWrite_MaterialsDeduplicated(t *testing.T) {
         },
         {
             "buffer": 0,
-            "byteOffset": 42,
+            "byteOffset": 44,
             "byteLength": 36,
             "target": 34962
         },
         {
             "buffer": 0,
-            "byteOffset": 78,
+            "byteOffset": 80,
             "byteLength": 6,
             "target": 34963
         }
@@ -2590,6 +2590,222 @@ func TestWrite_MeshesDeduplicated(t *testing.T) {
             "nodes": [
                 0,
                 1
+            ]
+        }
+    ]
+}`, buf.String())
+}
+func TestWrite_MeshesGpuInstanced(t *testing.T) {
+	// ARRANGE ================================================================
+	tri := modeling.NewTriangleMesh([]int{0, 1, 2}).
+		SetFloat3Attribute(
+			modeling.PositionAttribute,
+			[]vector3.Float64{
+				vector3.New(0., 0., 0.),
+				vector3.New(0., 1., 0.),
+				vector3.New(1., 0., 0.),
+			},
+		)
+
+	buf := bytes.Buffer{}
+
+	// ACT ====================================================================
+	roughness := 0.
+	material := &gltf.PolyformMaterial{
+		Name: "My Material",
+		PbrMetallicRoughness: &gltf.PolyformPbrMetallicRoughness{
+			BaseColorFactor: color.RGBA{255, 100, 80, 255},
+			RoughnessFactor: &roughness,
+		},
+	}
+	rightV := vector3.New[float64](2, 0, 0)
+	leftV := vector3.New[float64](-2, 0, -0)
+	scaleUniform15 := vector3.New[float64](1.5, 1.5, 1.5)
+	scaleDistort := vector3.New[float64](0.5, 2.5, 0.5)
+	rotQuat := quaternion.FromTheta(-math.Pi/2, vector3.New[float64](1, 0, 0))
+
+	trsRight := trs.New(rightV, quaternion.Identity(), scaleUniform15)
+	trsLeft := trs.New(leftV, rotQuat, scaleDistort)
+
+	err := gltf.WriteText(gltf.PolyformScene{
+		Models: []gltf.PolyformModel{
+			{Name: "mesh_right", Mesh: &tri, Material: material, TRS: &trsRight},
+			{Name: "mesh_left", Mesh: &tri, Material: material, TRS: &trsLeft},
+		},
+		UseGpuInstancing: true,
+	}, &buf)
+
+	// ASSERT =================================================================
+	assert.NoError(t, err)
+	assert.Equal(t, `{
+    "extensionsUsed": [
+        "EXT_mesh_gpu_instancing"
+    ],
+    "extensionsRequired": [
+        "EXT_mesh_gpu_instancing"
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 3,
+            "max": [
+                1,
+                1,
+                0
+            ],
+            "min": [
+                0,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "componentType": 5123,
+            "type": "SCALAR",
+            "count": 3
+        },
+        {
+            "bufferView": 2,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 2,
+            "max": [
+                2,
+                0,
+                0
+            ],
+            "min": [
+                -2,
+                0,
+                0
+            ]
+        },
+        {
+            "bufferView": 3,
+            "componentType": 5126,
+            "type": "VEC3",
+            "count": 2,
+            "max": [
+                1.5,
+                2.5,
+                1.5
+            ],
+            "min": [
+                0.5,
+                1.5,
+                0.5
+            ]
+        },
+        {
+            "bufferView": 4,
+            "componentType": 5126,
+            "type": "VEC4",
+            "count": 2,
+            "max": [
+                0,
+                0,
+                0,
+                1
+            ],
+            "min": [
+                -0.7071067811865475,
+                -0,
+                -0,
+                0.7071067811865476
+            ]
+        }
+    ],
+    "asset": {
+        "version": "2.0",
+        "generator": "https://github.com/EliCDavis/polyform"
+    },
+    "buffers": [
+        {
+            "byteLength": 124,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAABAAIAAAAAAABAAAAAAAAAAAAAAADAAAAAAAAAAAAAAMA/AADAPwAAwD8AAAA/AAAgQAAAAD8AAAAAAAAAAAAAAAAAAIA/8wQ1vwAAAIAAAACA8wQ1Pw=="
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 6,
+            "target": 34963
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 44,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 68,
+            "byteLength": 24,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 92,
+            "byteLength": 32,
+            "target": 34962
+        }
+    ],
+    "materials": [
+        {
+            "name": "My Material",
+            "pbrMetallicRoughness": {
+                "baseColorFactor": [
+                    1,
+                    0.392,
+                    0.314,
+                    1
+                ],
+                "roughnessFactor": 0
+            }
+        }
+    ],
+    "meshes": [
+        {
+            "name": "mesh_right",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0
+                    },
+                    "indices": 1,
+                    "material": 0
+                }
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "extensions": {
+                "EXT_mesh_gpu_instancing": {
+                    "attributes": {
+                        "ROTATION": 4,
+                        "SCALE": 3,
+                        "TRANSLATION": 2
+                    }
+                }
+            },
+            "mesh": 0,
+            "name": "mesh_right"
+        }
+    ],
+    "scenes": [
+        {
+            "nodes": [
+                0
             ]
         }
     ]

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -3,6 +3,7 @@ package gltf_test
 import (
 	"bytes"
 	"errors"
+	"github.com/EliCDavis/polyform/math/trs"
 	"image/color"
 	"math"
 	"testing"
@@ -2460,10 +2461,13 @@ func TestWrite_MeshesDeduplicated(t *testing.T) {
 	scaleDistort := vector3.New[float64](0.5, 2.5, 0.5)
 	rotQuat := quaternion.FromTheta(-math.Pi/2, vector3.New[float64](1, 0, 0))
 
+	trsRight := trs.New(rightV, quaternion.Identity(), scaleUniform15)
+	trsLeft := trs.New(leftV, rotQuat, scaleDistort)
+
 	err := gltf.WriteText(gltf.PolyformScene{
 		Models: []gltf.PolyformModel{
-			{Name: "mesh_right", Mesh: &tri, Material: material, Translation: &rightV, Scale: &scaleUniform15},
-			{Name: "mesh_left", Mesh: &tri, Material: material, Translation: &leftV, Scale: &scaleDistort, Rotation: &rotQuat},
+			{Name: "mesh_right", Mesh: &tri, Material: material, TRS: &trsRight},
+			{Name: "mesh_left", Mesh: &tri, Material: material, TRS: &trsLeft},
 		},
 	}, &buf)
 
@@ -2629,10 +2633,13 @@ func TestWrite_MeshesDifferentMatsPreserved(t *testing.T) {
 	scaleDistort := vector3.New[float64](0.5, 2.5, 0.5)
 	rotQuat := quaternion.FromTheta(-math.Pi/2, vector3.New[float64](1, 0, 0))
 
+	trsRight := trs.New(rightV, quaternion.Identity(), scaleUniform15)
+	trsLeft := trs.New(leftV, rotQuat, scaleDistort)
+
 	err := gltf.WriteText(gltf.PolyformScene{
 		Models: []gltf.PolyformModel{
-			{Name: "mesh_right", Mesh: &tri, Material: materialLeft, Translation: &rightV, Scale: &scaleUniform15},
-			{Name: "mesh_left", Mesh: &tri, Material: materialRight, Translation: &leftV, Scale: &scaleDistort, Rotation: &rotQuat},
+			{Name: "mesh_right", Mesh: &tri, Material: materialLeft, TRS: &trsRight},
+			{Name: "mesh_left", Mesh: &tri, Material: materialRight, TRS: &trsLeft},
 		},
 	}, &buf)
 

--- a/formats/gltf/write_test.go
+++ b/formats/gltf/write_test.go
@@ -3,13 +3,13 @@ package gltf_test
 import (
 	"bytes"
 	"errors"
-	"github.com/EliCDavis/polyform/math/trs"
 	"image/color"
 	"math"
 	"testing"
 
 	"github.com/EliCDavis/polyform/formats/gltf"
 	"github.com/EliCDavis/polyform/math/quaternion"
+	"github.com/EliCDavis/polyform/math/trs"
 	"github.com/EliCDavis/polyform/modeling"
 	"github.com/EliCDavis/vector/vector2"
 	"github.com/EliCDavis/vector/vector3"

--- a/formats/gltf/writer.go
+++ b/formats/gltf/writer.go
@@ -339,7 +339,15 @@ func rgbToFloatArr(c color.Color) [3]float64 {
 }
 
 func (w *Writer) AddScene(scene PolyformScene) error {
+	var instances instanceTracker
+
+	// First pass: process all models, collect mesh data and tracking instances
 	for _, model := range scene.Models {
+		// Validate that if GPU instances are provided, the UseGpuInstancing flag is set
+		if len(model.GpuInstances) > 0 && !scene.UseGpuInstancing {
+			return fmt.Errorf("model %q has GPU instances defined but scene.UseGpuInstancing is not set", model.Name)
+		}
+
 		meshIndex, err := w.AddModel(model)
 		if err != nil {
 			return fmt.Errorf("failed to add model %q: %w", model.Name, err)
@@ -347,72 +355,33 @@ func (w *Writer) AddScene(scene PolyformScene) error {
 			continue // mesh was not added to scene, ignore and continue
 		}
 
-		// Create node with transforms for this model
-		nodeIndex := len(w.nodes)
-		newNode := Node{
-			Mesh: &meshIndex,
-			Name: model.Name,
+		// Create a model instance for the base model's TRS
+		modelInst := modelInstance{
+			meshIndex: meshIndex,
+			trs:       model.TRS,
+			name:      model.Name,
 		}
 
-		if model.Translation != nil {
-			arr := model.Translation.ToFixedArr()
-			newNode.Translation = &arr
-		}
+		// Add to instance tracker - this will create a unique group for animated models
+		instances.add(meshIndex, modelInst, model.Skeleton, model.Animations)
 
-		if model.Rotation != nil {
-			arr := model.Rotation.ToArr()
-			newNode.Rotation = &arr
-		}
-
-		if model.Scale != nil {
-			arr := model.Scale.ToFixedArr()
-			newNode.Scale = &arr
-		}
-
+		// Handle GPU instances if present
 		if len(model.GpuInstances) > 0 {
-			if newNode.Extensions == nil {
-				newNode.Extensions = make(map[string]any)
+			for _, t := range model.GpuInstances {
+				gpuInstance := modelInstance{
+					meshIndex: meshIndex,
+					trs:       &t,
+					name:      model.Name,
+				}
+				instances.add(meshIndex, gpuInstance, model.Skeleton, model.Animations)
 			}
-			w.extensionsUsed[extGpuInstancingID] = true
-
-			instances := ExtGpuInstancing{
-				Attributes: make(map[string]int),
-			}
-
-			positions := make([]vector3.Float64, len(model.GpuInstances))
-			rotations := make([]vector4.Float64, len(model.GpuInstances))
-			scales := make([]vector3.Float64, len(model.GpuInstances))
-			for i, t := range model.GpuInstances {
-				positions[i] = t.Position()
-				rotations[i] = t.Rotation().Vector4()
-				scales[i] = t.Scale()
-			}
-
-			instances.Attributes["TRANSLATION"] = len(w.accessors)
-			w.WriteVector3(AccessorComponentType_FLOAT, iter.Array(positions))
-
-			instances.Attributes["SCALE"] = len(w.accessors)
-			w.WriteVector3(AccessorComponentType_FLOAT, iter.Array(scales))
-
-			instances.Attributes["ROTATION"] = len(w.accessors)
-			w.WriteVector4(AccessorComponentType_FLOAT, iter.Array(rotations))
-
-			newNode.Extensions[extGpuInstancingID] = instances
 		}
+	}
 
-		w.nodes = append(w.nodes, newNode)
-		w.scene = append(w.scene, nodeIndex)
-
-		skinNode := nodeIndex
-		// Handle any skeleton/animation data
-		if model.Skeleton != nil {
-			var skinIndex *int
-			skinIndex, skinNode = w.AddSkin(*model.Skeleton)
-			w.nodes[nodeIndex].Skin = skinIndex
-		}
-
-		if len(model.Animations) > 0 {
-			w.AddAnimations(model.Animations, *model.Skeleton, skinNode)
+	// Second pass: serialize instances, either as individual nodes or using GPU instancing
+	for _, group := range instances.groups {
+		if err := w.serializeInstances(group, scene.UseGpuInstancing); err != nil {
+			return fmt.Errorf("failed to serialize instances: %w", err)
 		}
 	}
 
@@ -421,6 +390,120 @@ func (w *Writer) AddScene(scene PolyformScene) error {
 		w.AddLight(light)
 	}
 
+	return nil
+}
+
+// serializeInstances processes the instance groups and serializes them as GLTF nodes
+// Returns an error if animation models with multiple instances are found when GPU instancing is disabled
+func (w *Writer) serializeInstances(group modelInstanceGroup, useGpuInstancing bool) error {
+	// Skip groups with no instances
+	if len(group.instances) == 0 {
+		return nil
+	}
+
+	if useGpuInstancing {
+		w.extensionsUsed[extGpuInstancingID] = true
+
+		// Create a node for the animated model
+		nodeIndex := len(w.nodes)
+		newNode := Node{
+			Mesh: &group.meshIndex,
+			Name: group.instances[0].name, //In case of GPU instances all names will be the same.
+		}
+		newNode.Extensions = make(map[string]any)
+
+		positions := make([]vector3.Float64, 0, len(group.instances))
+		rotations := make([]vector4.Float64, 0, len(group.instances))
+		scales := make([]vector3.Float64, 0, len(group.instances))
+
+		for i := 0; i < len(group.instances); i++ {
+			if group.instances[i].trs != nil {
+				positions = append(positions, group.instances[i].trs.Position())
+				rotations = append(rotations, group.instances[i].trs.Rotation().Vector4())
+				scales = append(scales, group.instances[i].trs.Scale())
+			}
+		}
+
+		// Create instancing attributes
+		instances := ExtGpuInstancing{
+			Attributes: make(map[string]int),
+		}
+
+		instances.Attributes["TRANSLATION"] = len(w.accessors)
+		w.WriteVector3(AccessorComponentType_FLOAT, iter.Array(positions))
+
+		instances.Attributes["SCALE"] = len(w.accessors)
+		w.WriteVector3(AccessorComponentType_FLOAT, iter.Array(scales))
+
+		instances.Attributes["ROTATION"] = len(w.accessors)
+		w.WriteVector4(AccessorComponentType_FLOAT, iter.Array(rotations))
+
+		newNode.Extensions[extGpuInstancingID] = instances
+
+		w.nodes = append(w.nodes, newNode)
+		w.scene = append(w.scene, nodeIndex)
+
+		if group.isAnimated() {
+			skinNode := nodeIndex
+			if group.skeleton != nil {
+				var skinIndex *int
+				skinIndex, skinNode = w.AddSkin(*group.skeleton)
+				w.nodes[nodeIndex].Skin = skinIndex
+			}
+
+			if len(group.animations) > 0 {
+				w.AddAnimations(group.animations, *group.skeleton, skinNode)
+			}
+		}
+	} else {
+		if group.isAnimated() && len(group.instances) > 1 {
+			// This really has already been checked earlier and should never happen.
+			// This limitation can be lifted once node children mechanics is implemented.
+			return fmt.Errorf("animated model %q has multiple instances, but GPU instancing is disabled", group.instances[0].name)
+		}
+
+		// Create individual nodes for each instance
+		for _, instance := range group.instances {
+			nodeIndex := len(w.nodes)
+			newNode := Node{
+				Mesh: &group.meshIndex,
+				Name: instance.name,
+			}
+
+			// Set transformations
+			if instance.trs != nil {
+				posArr := instance.trs.Position().ToFixedArr()
+				scaleArr := instance.trs.Scale().ToFixedArr()
+
+				// Only set rotation if it's not identity quaternion
+				rot := instance.trs.Rotation()
+				if rot.W() != 1 || rot.Dir().X() != 0 || rot.Dir().Y() != 0 || rot.Dir().Z() != 0 {
+					rotArr := rot.ToArr()
+					newNode.Rotation = &rotArr
+				}
+
+				newNode.Translation = &posArr
+				newNode.Scale = &scaleArr
+			}
+
+			w.nodes = append(w.nodes, newNode)
+			w.scene = append(w.scene, nodeIndex)
+
+			// If this triggers - there always only one instance
+			if group.isAnimated() {
+				skinNode := nodeIndex
+				if group.skeleton != nil {
+					var skinIndex *int
+					skinIndex, skinNode = w.AddSkin(*group.skeleton)
+					w.nodes[nodeIndex].Skin = skinIndex
+				}
+
+				if len(group.animations) > 0 {
+					w.AddAnimations(group.animations, *group.skeleton, skinNode)
+				}
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
_API draft proposal, not for merging_

Hi @EliCDavis 

I noticed you've added a way to enable `EXT_mesh_gpu_instancing` short after my work on mesh deduplication was merged. I'm now looking to use instancing properly on the client side, not just for file size reduction, but for faster rendering as well, and that means I need to make use of this extension.

However, this API with `PolyformModel.GpuInstances` is not compatible with the earlier `PolyformModel.T/R/S` implementation I've added, so I'm not sure what is the preferred way now. 

In this PR I'm suggesting a different API that will create a single way to control these two related features.

**Proposal**
1. Add `PolyformModel.UseGpuInstancing bool` flag, replacing `PolyformModel.GpuInstances`. This will be the only public API feature directly related to this function.
2. If the flag is set on a given model - use existing mesh deduplication mechanics to find other models that reference the same mesh.
3. Treat all models of a given mesh as enabled for GPU instancing, if any model instance has the flag set.
4. Internally build the list of instances and create a single node with one mesh reference and necessary data accessors.

**Rationale**
I see mesh deduplication  and GPU instancing as separate, but related features. Mesh deduplication and creating nodes that use references to the same mesh within a single file can be done using server-side only means, with no knowledge of the client's implementation, and has value in itself. Adding GPU instancing - builds on top of this mechanics, but expects client support of a custom (albeit very popular) extension, which is strictly speaking not part of the core format.

In the current state - these two features are disconnected and not compatible with each other. Mesh dedup implementation expects each instance to be declared as a separate model, while GPU instancing implementation requires a single model with a list of TRS values for each instance. So switching between them requires changing implementation for the library clients.

Proposed approach allows flexibility to enable the feature where necessary, but not having to materially change the logic if the feature has to be disabled if it is not supported by a given client. And it still allows using the core format feature of mesh deduplication even if the extension is not supported.

---
I assume the current state of this API is temporary, and this fork in the road will lead down one or other way. 
I'm happy with either way, but I would like to resolve this so I don't have to change my implementation again later on. 
If you're happy with my proposal - I'll create an implementation for this API change.


