### PR TITLE
Prevent crash on no-material OBJ

### DIFF
--- a/formats/obj/fs.go
+++ b/formats/obj/fs.go
@@ -44,6 +44,9 @@ func Load(objPath string) (*Scene, error) {
 
 	for _, o := range scene.Objects {
 		for i, e := range o.Entries {
+			if e.Material == nil {
+				continue
+			}
 			o.Entries[i].Material = loadedMaterials[e.Material.Name]
 		}
 	}


### PR DESCRIPTION
OBJ without materials are perfectly valid, but I think this area has changed recently and now there is a nil-pionter crash here where there wasn't before. And this is on trying to open a file with no materials defined in it.

This check fixes the crash.