### PR TITLE
fix: better sri ci handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 
-      - name: Restore Nix-cached Release Artifacts
-        run: nix build .#release -Lo ./artifacts
+      - name: Build Nix-cached Release Artifacts
+        run: |
+          nix run .#sri-check-up --print-build-logs
+          nix build .#release --print-build-logs --out-link=./artifacts
 
   pages:
     runs-on: ubuntu-latest
@@ -37,5 +39,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 
-      - name: Restore Nix-cached Pages Artifacts
-        run: nix build .#pages -Lo ./dist
+      - name: Build Nix-cached Pages Artifacts
+        run: |
+          nix run .#sri-check-up --print-build-logs
+          nix build .#pages --print-build-logs --out-link=./dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 
-      - name: Restore Nix-cached Release Artifacts
-        run: nix build .#release -Lo ./artifacts
-
-      - name: Publish GitHub Release
+      - name: Push Nix-cached Release Artifacts
         run: |
-          gh release upload $GITHUB_REF_NAME ./artifacts/* --clobber
+          nix run .#sri-check-up --print-build-logs
+          nix run .#release --print-build-logs
 
   deploy:
     runs-on: ubuntu-latest
@@ -45,7 +43,9 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Restore Nix-cached Pages Artifacts
-        run: nix build .#pages -Lo ./dist
+        run: |
+          nix run .#sri-check-up --print-build-logs
+          nix build .#pages --print-build-logs --out-link=./dist
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
- Renames "update-sris" -> "sri-check-up"
- Refactors this script so that it both handles updating the SRIs when run locally, but also prints the SRI difference to the log when in CI.
- Uses this script in workflows to check the SRIs before continuing with expensive build and release steps.
- Refactors the 'apps' section into main let expression for use in build phases if needed.
- 
example output seen in CI:
```bash
$: nix run .#sri-check-up
package-lock.json.sri mismatch
specified: sha256-uea6z39yYjpLTjq+ne3NJdabTQ/N91tLtBqfQMSYcAI=
got: sha256-gF8IDK1WKmNwXcIfm62kkDSzSxIceKgpSxuwzQDlmcQ=
If this difference is expected, please replace the SRI hash in this file with the one we got
```