### PR TITLE
Color Fields

### DIFF
--- a/generator/edit/server_test.go
+++ b/generator/edit/server_test.go
@@ -128,7 +128,7 @@ func TestServer(t *testing.T) {
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &out))
 				assert.Equal(t, `{"displayName":"parameter.Value[float64]","info":"","type":"Float64","path":"generator/parameter","outputs":{"Value":{"type":"float64"}},"parameter":{"name":"","description":"","type":"float64","currentValue":1}}`, string(out.NodeTypes[0]))
 				assert.Equal(t, `{"displayName":"MyVariable","info":"Variable HTTP test","type":"MyVariable","path":"generator/variable","outputs":{"Value":{"type":"float64"}}}`, string(out.NodeTypes[1]))
-				assert.Equal(t, `{"displayName":"Add[float64]","info":"","type":"Sum","path":"math","outputs":{"Float":{"type":"float64"},"Int":{"type":"int"}},"inputs":{"Values":{"type":"float64","isArray":true,"description":"The nodes to sum"}}}`, string(out.NodeTypes[2]))
+				assert.Equal(t, `{"displayName":"Add[float64]","info":"Adds two or more values together.","type":"Sum","path":"math","outputs":{"Float":{"type":"float64"},"Int":{"type":"int"}},"inputs":{"Values":{"type":"float64","isArray":true,"description":"The values to sum."}}}`, string(out.NodeTypes[2]))
 				assert.Len(t, out.NodeTypes, 3)
 			},
 		},

--- a/math/sdf/colored_union.go
+++ b/math/sdf/colored_union.go
@@ -1,0 +1,185 @@
+package sdf
+
+import (
+	"errors"
+	"math"
+
+	"github.com/EliCDavis/polyform/drawing/coloring"
+	"github.com/EliCDavis/polyform/math/sample"
+	"github.com/EliCDavis/polyform/nodes"
+	"github.com/EliCDavis/vector/vector3"
+)
+
+// ColorField is a color at every point in space, the color-channel
+// equivalent of sample.Vec3ToFloat.
+type ColorField func(vector3.Float64) coloring.Color
+
+// ConstantColor builds a ColorField that returns the same color
+// everywhere - the common case for a single primitive.
+func ConstantColor(c coloring.Color) ColorField {
+	return func(vector3.Float64) coloring.Color {
+		return c
+	}
+}
+
+// ColoredField pairs a distance field with a color field over the same
+// space, so a union combinator can blend both consistently using the same
+// "how far into the transition zone am I" weight for each.
+type ColoredField struct {
+	Distance sample.Vec3ToFloat
+	Color    ColorField
+}
+
+// SmoothUnionColored combines two or more ColoredFields the same way
+// SmoothUnion combines their bare distance fields, and blends color using
+// the identical blend weight the distance union computes - so color
+// transitions over exactly the same physical region the geometry does,
+// instead of snapping at a hard edge or drifting independently of it.
+//
+// For 3+ fields, only the two nearest at a given point are blended - the
+// same nearest-two rule SmoothUnion's own N-ary case uses - so a point
+// deep inside one field is unaffected by a color on the far side of the
+// model, no matter how many other fields are in the union.
+func SmoothUnionColored(radius float64, fields ...ColoredField) ColoredField {
+	if len(fields) == 0 {
+		panic("no fields to union")
+	}
+	if len(fields) == 1 {
+		return fields[0]
+	}
+
+	distances := make([]sample.Vec3ToFloat, len(fields))
+	for i, f := range fields {
+		distances[i] = f.Distance
+	}
+	distanceField := SmoothUnion(radius, distances...)
+
+	colorField := func(v vector3.Float64) coloring.Color {
+		min1, min2 := math.Inf(1), math.Inf(1)
+		idx1, idx2 := 0, 0
+		for i, f := range fields {
+			d := f.Distance(v)
+			if d < min1 {
+				min1, min2 = d, min1
+				idx2 = idx1
+				idx1 = i
+			} else if d < min2 {
+				min2 = d
+				idx2 = i
+			}
+		}
+
+		colorA := fields[idx1].Color(v)
+		if radius <= 0 {
+			return colorA // hard union: the nearer field's color wins outright
+		}
+
+		colorB := fields[idx2].Color(v)
+		h := math.Max(radius-math.Abs(min1-min2), 0) / radius
+		// h=0 far from the boundary (idx1 clearly nearer) -> pure colorA.
+		// h=1 exactly on the boundary (min1==min2) -> an even 50/50 blend.
+		return colorA.Lerp(colorB, h*0.5)
+	}
+
+	return ColoredField{Distance: distanceField, Color: colorField}
+}
+
+// UnionColored is the hard-union equivalent of SmoothUnionColored: at
+// each point, whichever field is nearest wins outright - both its
+// distance and its color - with a crisp seam and no blending, the same
+// relationship Union has to SmoothUnion for plain fields.
+func UnionColored(fields ...ColoredField) ColoredField {
+	if len(fields) == 0 {
+		panic("no fields to union")
+	}
+	if len(fields) == 1 {
+		return fields[0]
+	}
+
+	distances := make([]sample.Vec3ToFloat, len(fields))
+	for i, f := range fields {
+		distances[i] = f.Distance
+	}
+	distanceField := Union(distances...)
+
+	colorField := func(v vector3.Float64) coloring.Color {
+		minDist := math.Inf(1)
+		winner := 0
+		for i, f := range fields {
+			d := f.Distance(v)
+			if d < minDist {
+				minDist = d
+				winner = i
+			}
+		}
+		return fields[winner].Color(v)
+	}
+
+	return ColoredField{Distance: distanceField, Color: colorField}
+}
+
+type WithColorNode struct {
+	Field nodes.Output[sample.Vec3ToFloat] `description:"The field to attach a color to."`
+	Color nodes.Output[coloring.Color]     `description:"The color given to every point in Field."`
+}
+
+func (n WithColorNode) Description() string {
+	return "Pairs an existing field with a constant color, so it can be combined with other colored fields via SmoothUnionColoredNode."
+}
+
+func (n WithColorNode) Out(out *nodes.StructOutput[ColoredField]) {
+	field := nodes.TryGetOutputValue(out, n.Field, nullField)
+	color := nodes.TryGetOutputValue(out, n.Color, coloring.Color{A: 1})
+	out.Set(ColoredField{
+		Distance: field,
+		Color:    ConstantColor(color),
+	})
+}
+
+type SmoothUnionColoredNode struct {
+	Fields []nodes.Output[ColoredField] `description:"The colored fields to combine."`
+	Radius nodes.Output[float64]        `description:"Width of the blend region in world units, same meaning as SmoothUnionNode's Radius. Zero or less is a hard union: color follows whichever field is nearer outright, with no blending. Defaults to 0.1."`
+}
+
+func (n SmoothUnionColoredNode) Description() string {
+	return "Combines two or more colored fields, blending both their shapes and their colors smoothly where they meet, using the same blend weight for each."
+}
+
+func (n SmoothUnionColoredNode) Union(out *nodes.StructOutput[ColoredField]) {
+	fields := nodes.GetOutputValues(out, n.Fields)
+	if len(fields) == 0 {
+		out.CaptureError(errors.New("No fields provided to union"))
+		return
+	}
+	out.Set(SmoothUnionColored(nodes.TryGetOutputValue(out, n.Radius, .1), fields...))
+}
+
+type UnionColoredNode struct {
+	Fields []nodes.Output[ColoredField] `description:"The colored fields to combine."`
+}
+
+func (n UnionColoredNode) Description() string {
+	return "Boolean union of two or more colored fields - at each point, whichever field is nearest wins outright, both its shape and its color, with a crisp seam and no blending where they meet."
+}
+
+func (n UnionColoredNode) Union(out *nodes.StructOutput[ColoredField]) {
+	fields := nodes.GetOutputValues(out, n.Fields)
+	if len(fields) == 0 {
+		out.CaptureError(errors.New("No fields provided to union"))
+		return
+	}
+	out.Set(UnionColored(fields...))
+}
+
+type ColoredFieldDistanceNode struct {
+	Field nodes.Output[ColoredField] `description:"The colored field to extract the plain distance field from."`
+}
+
+func (n ColoredFieldDistanceNode) Description() string {
+	return "Extracts the plain distance field from a colored field, for wiring into MarchNode - a colored field's own color only becomes usable after marching, via ApplyColorFieldNode."
+}
+
+func (n ColoredFieldDistanceNode) Out(out *nodes.StructOutput[sample.Vec3ToFloat]) {
+	field := nodes.TryGetOutputValue(out, n.Field, ColoredField{})
+	out.Set(field.Distance)
+}

--- a/math/sdf/colored_union.go
+++ b/math/sdf/colored_union.go
@@ -10,36 +10,24 @@ import (
 	"github.com/EliCDavis/vector/vector3"
 )
 
-// ColorField is a color at every point in space, the color-channel
-// equivalent of sample.Vec3ToFloat.
+// ColorField is a color at every point in space.
 type ColorField func(vector3.Float64) coloring.Color
 
-// ConstantColor builds a ColorField that returns the same color
-// everywhere - the common case for a single primitive.
+// ConstantColor returns a ColorField that always returns c.
 func ConstantColor(c coloring.Color) ColorField {
 	return func(vector3.Float64) coloring.Color {
 		return c
 	}
 }
 
-// ColoredField pairs a distance field with a color field over the same
-// space, so a union combinator can blend both consistently using the same
-// "how far into the transition zone am I" weight for each.
+// ColoredField pairs a distance field with a color over the same space.
 type ColoredField struct {
 	Distance sample.Vec3ToFloat
 	Color    ColorField
 }
 
-// SmoothUnionColored combines two or more ColoredFields the same way
-// SmoothUnion combines their bare distance fields, and blends color using
-// the identical blend weight the distance union computes - so color
-// transitions over exactly the same physical region the geometry does,
-// instead of snapping at a hard edge or drifting independently of it.
-//
-// For 3+ fields, only the two nearest at a given point are blended - the
-// same nearest-two rule SmoothUnion's own N-ary case uses - so a point
-// deep inside one field is unaffected by a color on the far side of the
-// model, no matter how many other fields are in the union.
+// SmoothUnionColored blends colored fields, using one weight for both
+// shape and color.
 func SmoothUnionColored(radius float64, fields ...ColoredField) ColoredField {
 	if len(fields) == 0 {
 		panic("no fields to union")
@@ -84,10 +72,8 @@ func SmoothUnionColored(radius float64, fields ...ColoredField) ColoredField {
 	return ColoredField{Distance: distanceField, Color: colorField}
 }
 
-// UnionColored is the hard-union equivalent of SmoothUnionColored: at
-// each point, whichever field is nearest wins outright - both its
-// distance and its color - with a crisp seam and no blending, the same
-// relationship Union has to SmoothUnion for plain fields.
+// UnionColored combines colored fields with a hard union - the nearest
+// field's distance and color win outright, with no blending.
 func UnionColored(fields ...ColoredField) ColoredField {
 	if len(fields) == 0 {
 		panic("no fields to union")
@@ -124,7 +110,7 @@ type WithColorNode struct {
 }
 
 func (n WithColorNode) Description() string {
-	return "Pairs an existing field with a constant color, so it can be combined with other colored fields via SmoothUnionColoredNode."
+	return "Pairs a field with a constant color to make a colored field."
 }
 
 func (n WithColorNode) Out(out *nodes.StructOutput[ColoredField]) {
@@ -138,11 +124,11 @@ func (n WithColorNode) Out(out *nodes.StructOutput[ColoredField]) {
 
 type SmoothUnionColoredNode struct {
 	Fields []nodes.Output[ColoredField] `description:"The colored fields to combine."`
-	Radius nodes.Output[float64]        `description:"Width of the blend region in world units, same meaning as SmoothUnionNode's Radius. Zero or less is a hard union: color follows whichever field is nearer outright, with no blending. Defaults to 0.1."`
+	Radius nodes.Output[float64]        `description:"Width of the blend region in world units. Zero or less is a hard union. Defaults to 0.1."`
 }
 
 func (n SmoothUnionColoredNode) Description() string {
-	return "Combines two or more colored fields, blending both their shapes and their colors smoothly where they meet, using the same blend weight for each."
+	return "Blends two or more colored fields together, smoothing both shape and color where they meet."
 }
 
 func (n SmoothUnionColoredNode) Union(out *nodes.StructOutput[ColoredField]) {
@@ -159,7 +145,7 @@ type UnionColoredNode struct {
 }
 
 func (n UnionColoredNode) Description() string {
-	return "Boolean union of two or more colored fields - at each point, whichever field is nearest wins outright, both its shape and its color, with a crisp seam and no blending where they meet."
+	return "Union of two or more colored fields - the nearest field wins outright, shape and color, with a crisp seam."
 }
 
 func (n UnionColoredNode) Union(out *nodes.StructOutput[ColoredField]) {
@@ -176,7 +162,7 @@ type ColoredFieldDistanceNode struct {
 }
 
 func (n ColoredFieldDistanceNode) Description() string {
-	return "Extracts the plain distance field from a colored field, for wiring into MarchNode - a colored field's own color only becomes usable after marching, via ApplyColorFieldNode."
+	return "Extracts the distance field from a colored field."
 }
 
 func (n ColoredFieldDistanceNode) Out(out *nodes.StructOutput[sample.Vec3ToFloat]) {

--- a/math/sdf/colored_union_test.go
+++ b/math/sdf/colored_union_test.go
@@ -16,8 +16,7 @@ func TestSmoothUnionColoredTwoSpheres(t *testing.T) {
 	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
 	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
 
-	// Two unit spheres 1.5 apart, so they overlap - a real blend region
-	// exists between them, not just tangency.
+	// Two unit spheres 1.5 apart, so they actually overlap.
 	a := sdf.ColoredField{
 		Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1),
 		Color:    sdf.ConstantColor(red),
@@ -45,8 +44,7 @@ func TestSmoothUnionColoredTwoSpheres(t *testing.T) {
 			pos: vector3.New(0.75, 0., 0.), wantR: 0.5, wantB: 0.5, distSign: -1,
 		},
 		"far outside both, clearly on A's side": {
-			// (-10,0,0) is 9 units from A's surface and 10.5 from B's -
-			// A is unambiguously nearer, so its color should win outright.
+			// Nearer A's surface than B's, so A's color should win.
 			pos: vector3.New(-10., 0., 0.), wantR: 1, wantB: 0, distSign: 1,
 		},
 	}
@@ -74,8 +72,7 @@ func TestSmoothUnionColoredNearestTwoIgnoresDistantThirdField(t *testing.T) {
 
 	a := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1), Color: sdf.ConstantColor(red)}
 	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(green)}
-	// Far away on the other side of the model - should have zero influence
-	// on A/B's own blend region.
+	// Far away - should have zero influence on A/B's blend.
 	c := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 100.), 1), Color: sdf.ConstantColor(blue)}
 
 	union := sdf.SmoothUnionColored(0.5, a, b, c)
@@ -112,8 +109,7 @@ func TestUnionColoredTwoSpheres(t *testing.T) {
 		})
 	}
 
-	// A hard-union distance should exactly match the plain (uncolored)
-	// Union of the same two fields, at a real sample of points.
+	// Distance should match the plain Union of the same fields.
 	plainUnion := sdf.Union(a.Distance, b.Distance)
 	for _, p := range []vector3.Float64{
 		vector3.New(0., 0., 0.), vector3.New(0.75, 0., 0.), vector3.New(10., 10., 10.),

--- a/math/sdf/colored_union_test.go
+++ b/math/sdf/colored_union_test.go
@@ -1,0 +1,222 @@
+package sdf_test
+
+import (
+	"testing"
+
+	"github.com/EliCDavis/polyform/drawing/coloring"
+	"github.com/EliCDavis/polyform/math/sample"
+	"github.com/EliCDavis/polyform/math/sdf"
+	"github.com/EliCDavis/polyform/nodes"
+	"github.com/EliCDavis/vector/vector3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmoothUnionColoredTwoSpheres(t *testing.T) {
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
+
+	// Two unit spheres 1.5 apart, so they overlap - a real blend region
+	// exists between them, not just tangency.
+	a := sdf.ColoredField{
+		Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1),
+		Color:    sdf.ConstantColor(red),
+	}
+	b := sdf.ColoredField{
+		Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1),
+		Color:    sdf.ConstantColor(blue),
+	}
+
+	union := sdf.SmoothUnionColored(0.5, a, b)
+
+	tests := map[string]struct {
+		pos      vector3.Float64
+		wantR    float64
+		wantB    float64
+		distSign float64 // +1 outside, -1 inside
+	}{
+		"deep inside A, far from the boundary": {
+			pos: vector3.New(0., 0., 0.), wantR: 1, wantB: 0, distSign: -1,
+		},
+		"deep inside B, far from the boundary": {
+			pos: vector3.New(1.5, 0., 0.), wantR: 0, wantB: 1, distSign: -1,
+		},
+		"exactly on the seam, equidistant from both centers": {
+			pos: vector3.New(0.75, 0., 0.), wantR: 0.5, wantB: 0.5, distSign: -1,
+		},
+		"far outside both, clearly on A's side": {
+			// (-10,0,0) is 9 units from A's surface and 10.5 from B's -
+			// A is unambiguously nearer, so its color should win outright.
+			pos: vector3.New(-10., 0., 0.), wantR: 1, wantB: 0, distSign: 1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := union.Distance(tc.pos)
+			if tc.distSign < 0 {
+				assert.Negative(t, d, "expected inside the union")
+			} else {
+				assert.Positive(t, d, "expected outside the union")
+			}
+
+			c := union.Color(tc.pos)
+			assert.InDelta(t, tc.wantR, c.R, 1e-9, "red channel")
+			assert.InDelta(t, tc.wantB, c.B, 1e-9, "blue channel")
+		})
+	}
+}
+
+func TestSmoothUnionColoredNearestTwoIgnoresDistantThirdField(t *testing.T) {
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+	green := coloring.Color{R: 0, G: 1, B: 0, A: 1}
+	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
+
+	a := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1), Color: sdf.ConstantColor(red)}
+	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(green)}
+	// Far away on the other side of the model - should have zero influence
+	// on A/B's own blend region.
+	c := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 100.), 1), Color: sdf.ConstantColor(blue)}
+
+	union := sdf.SmoothUnionColored(0.5, a, b, c)
+
+	got := union.Color(vector3.New(0.75, 0., 0.)) // the A/B seam
+	assert.InDelta(t, 0.5, got.R, 1e-9)
+	assert.InDelta(t, 0.5, got.G, 1e-9)
+	assert.InDelta(t, 0, got.B, 1e-9, "the distant blue sphere must not leak into the A/B seam")
+}
+
+func TestUnionColoredTwoSpheres(t *testing.T) {
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
+
+	a := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1), Color: sdf.ConstantColor(red)}
+	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(blue)}
+
+	union := sdf.UnionColored(a, b)
+
+	tests := map[string]struct {
+		pos  vector3.Float64
+		want coloring.Color
+	}{
+		"deep inside A": {pos: vector3.New(0., 0., 0.), want: red},
+		"deep inside B": {pos: vector3.New(1.5, 0., 0.), want: blue},
+		"slightly closer to A of the two, inside the overlap": {pos: vector3.New(0.7, 0., 0.), want: red},
+		"slightly closer to B of the two, inside the overlap": {pos: vector3.New(0.8, 0., 0.), want: blue},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := union.Color(tc.pos)
+			assert.Equal(t, tc.want, got, "hard union should give the nearer field's exact color, never a blend")
+		})
+	}
+
+	// A hard-union distance should exactly match the plain (uncolored)
+	// Union of the same two fields, at a real sample of points.
+	plainUnion := sdf.Union(a.Distance, b.Distance)
+	for _, p := range []vector3.Float64{
+		vector3.New(0., 0., 0.), vector3.New(0.75, 0., 0.), vector3.New(10., 10., 10.),
+	} {
+		assert.InDelta(t, plainUnion(p), union.Distance(p), 1e-9)
+	}
+}
+
+func TestUnionColoredNode(t *testing.T) {
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
+
+	a := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1), Color: sdf.ConstantColor(red)}
+	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(blue)}
+
+	node := &nodes.Struct[sdf.UnionColoredNode]{
+		Data: sdf.UnionColoredNode{
+			Fields: []nodes.Output[sdf.ColoredField]{
+				nodes.ConstOutput[sdf.ColoredField]{Val: a},
+				nodes.ConstOutput[sdf.ColoredField]{Val: b},
+			},
+		},
+	}
+
+	got := nodes.GetNodeOutputPort[sdf.ColoredField](node, "Union").Value()
+	assert.Equal(t, red, got.Color(vector3.New(0., 0., 0.)))
+	assert.Equal(t, blue, got.Color(vector3.New(1.5, 0., 0.)))
+}
+
+func TestUnionColoredNodeRequiresAtLeastOneField(t *testing.T) {
+	node := &nodes.Struct[sdf.UnionColoredNode]{}
+
+	var got sdf.ColoredField
+	require.NotPanics(t, func() {
+		got = nodes.GetNodeOutputPort[sdf.ColoredField](node, "Union").Value()
+	})
+	require.Nil(t, got.Distance, "no fields provided should capture an error, not set a usable field")
+}
+
+func TestWithColorNode(t *testing.T) {
+	sphere := sdf.Sphere(vector3.New(0., 0., 0.), 1)
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+
+	node := &nodes.Struct[sdf.WithColorNode]{
+		Data: sdf.WithColorNode{
+			Field: nodes.ConstOutput[sample.Vec3ToFloat]{Val: sphere},
+			Color: nodes.ConstOutput[coloring.Color]{Val: red},
+		},
+	}
+
+	got := nodes.GetNodeOutputPort[sdf.ColoredField](node, "Out").Value()
+	require.NotNil(t, got.Distance)
+	require.NotNil(t, got.Color)
+	assert.InDelta(t, -1.0, got.Distance(vector3.New(0., 0., 0.)), 1e-9)
+	assert.Equal(t, red, got.Color(vector3.New(0., 0., 0.)))
+	assert.Equal(t, red, got.Color(vector3.New(5., 5., 5.)), "color is constant everywhere, not just near the field")
+}
+
+func TestSmoothUnionColoredNode(t *testing.T) {
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
+
+	a := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1), Color: sdf.ConstantColor(red)}
+	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(blue)}
+
+	node := &nodes.Struct[sdf.SmoothUnionColoredNode]{
+		Data: sdf.SmoothUnionColoredNode{
+			Fields: []nodes.Output[sdf.ColoredField]{
+				nodes.ConstOutput[sdf.ColoredField]{Val: a},
+				nodes.ConstOutput[sdf.ColoredField]{Val: b},
+			},
+			Radius: nodes.ConstOutput[float64]{Val: 0.5},
+		},
+	}
+
+	got := nodes.GetNodeOutputPort[sdf.ColoredField](node, "Union").Value()
+	seam := got.Color(vector3.New(0.75, 0., 0.))
+	assert.InDelta(t, 0.5, seam.R, 1e-9)
+	assert.InDelta(t, 0.5, seam.B, 1e-9)
+}
+
+func TestSmoothUnionColoredNodeRequiresAtLeastOneField(t *testing.T) {
+	node := &nodes.Struct[sdf.SmoothUnionColoredNode]{}
+
+	var got sdf.ColoredField
+	require.NotPanics(t, func() {
+		got = nodes.GetNodeOutputPort[sdf.ColoredField](node, "Union").Value()
+	})
+	require.Nil(t, got.Distance, "no fields provided should capture an error, not set a usable field")
+}
+
+func TestColoredFieldDistanceNode(t *testing.T) {
+	field := sdf.ColoredField{
+		Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1),
+		Color:    sdf.ConstantColor(coloring.Color{R: 1, A: 1}),
+	}
+
+	node := &nodes.Struct[sdf.ColoredFieldDistanceNode]{
+		Data: sdf.ColoredFieldDistanceNode{
+			Field: nodes.ConstOutput[sdf.ColoredField]{Val: field},
+		},
+	}
+
+	got := nodes.GetNodeOutputPort[sample.Vec3ToFloat](node, "Out").Value()
+	assert.InDelta(t, -1.0, got(vector3.New(0., 0., 0.)), 1e-9)
+}

--- a/math/sdf/mirror.go
+++ b/math/sdf/mirror.go
@@ -49,14 +49,8 @@ func MirrorXYZ(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	}
 }
 
-// mirrorUnion reflects f across every axis flagged true and unions every
-// resulting copy together - evaluating f at each sign combination of the
-// mirrored axes and taking the minimum - rather than folding a query onto
-// one canonical side before evaluating f once. The fold (MirrorX etc.
-// above) silently discards whatever f actually defines on the non-
-// canonical side; this preserves it, at the cost of evaluating f once per
-// mirrored copy (2 calls for one axis, 4 for two, 8 for three) instead of
-// once.
+// mirrorUnion reflects f across the flagged axes and unions every
+// resulting copy together.
 func mirrorUnion(f sample.Vec3ToFloat, mirrorX, mirrorY, mirrorZ bool) sample.Vec3ToFloat {
 	xSigns := []float64{1}
 	if mirrorX {
@@ -85,8 +79,8 @@ func mirrorUnion(f sample.Vec3ToFloat, mirrorX, mirrorY, mirrorZ bool) sample.Ve
 }
 
 type MirrorNode struct {
-	Field nodes.Output[sample.Vec3ToFloat] `description:"The field to mirror. Each output port below reflects it across a different axis/plane through the origin; nothing is set on any output until this is connected."`
-	Union nodes.Output[bool]               `description:"When true (the default), every reflected copy is unioned with the original by evaluating the field on every mirrored side and combining the results, so real content already present on more than one side of the mirror plane is preserved instead of being silently overwritten. When false: cheaper but less safe - a query is folded onto one canonical side before the field is evaluated once, which discards whatever the field actually defines on the other side. Only set this false when the field being mirrored is known to have content on one side of every mirrored axis only, e.g. a single limb built entirely on the positive side."`
+	Field nodes.Output[sample.Vec3ToFloat] `description:"The field to mirror. Each output port reflects it across a different axis through the origin."`
+	Union nodes.Output[bool]               `description:"When true (default), unions every mirrored copy so content on both sides is preserved. When false, folds onto one side - cheaper, but only correct if the field has content on one side only."`
 }
 
 func (n MirrorNode) Description() string {

--- a/math/sdf/mirror.go
+++ b/math/sdf/mirror.go
@@ -49,17 +49,63 @@ func MirrorXYZ(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	}
 }
 
+// mirrorUnion reflects f across every axis flagged true and unions every
+// resulting copy together - evaluating f at each sign combination of the
+// mirrored axes and taking the minimum - rather than folding a query onto
+// one canonical side before evaluating f once. The fold (MirrorX etc.
+// above) silently discards whatever f actually defines on the non-
+// canonical side; this preserves it, at the cost of evaluating f once per
+// mirrored copy (2 calls for one axis, 4 for two, 8 for three) instead of
+// once.
+func mirrorUnion(f sample.Vec3ToFloat, mirrorX, mirrorY, mirrorZ bool) sample.Vec3ToFloat {
+	xSigns := []float64{1}
+	if mirrorX {
+		xSigns = append(xSigns, -1)
+	}
+	ySigns := []float64{1}
+	if mirrorY {
+		ySigns = append(ySigns, -1)
+	}
+	zSigns := []float64{1}
+	if mirrorZ {
+		zSigns = append(zSigns, -1)
+	}
+
+	return func(v vector3.Float64) float64 {
+		result := math.Inf(1)
+		for _, sx := range xSigns {
+			for _, sy := range ySigns {
+				for _, sz := range zSigns {
+					result = math.Min(result, f(vector3.New(v.X()*sx, v.Y()*sy, v.Z()*sz)))
+				}
+			}
+		}
+		return result
+	}
+}
+
 type MirrorNode struct {
 	Field nodes.Output[sample.Vec3ToFloat] `description:"The field to mirror. Each output port below reflects it across a different axis/plane through the origin; nothing is set on any output until this is connected."`
+	Union nodes.Output[bool]               `description:"When true (the default), every reflected copy is unioned with the original by evaluating the field on every mirrored side and combining the results, so real content already present on more than one side of the mirror plane is preserved instead of being silently overwritten. When false: cheaper but less safe - a query is folded onto one canonical side before the field is evaluated once, which discards whatever the field actually defines on the other side. Only set this false when the field being mirrored is known to have content on one side of every mirrored axis only, e.g. a single limb built entirely on the positive side."`
 }
 
 func (n MirrorNode) Description() string {
 	return "Reflects an SDF field across one or more axes through the origin, one output port per axis combination."
 }
 
+func (n MirrorNode) union(out nodes.ExecutionRecorder) bool {
+	return nodes.TryGetOutputValue(out, n.Union, true)
+}
+
 func (n MirrorNode) X(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorX(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, true, false, false))
+	} else {
+		out.Set(MirrorX(field))
 	}
 }
 
@@ -68,8 +114,14 @@ func (n MirrorNode) XDescription() string {
 }
 
 func (n MirrorNode) Y(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorY(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, false, true, false))
+	} else {
+		out.Set(MirrorY(field))
 	}
 }
 
@@ -78,8 +130,14 @@ func (n MirrorNode) YDescription() string {
 }
 
 func (n MirrorNode) Z(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorZ(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, false, false, true))
+	} else {
+		out.Set(MirrorZ(field))
 	}
 }
 
@@ -88,8 +146,14 @@ func (n MirrorNode) ZDescription() string {
 }
 
 func (n MirrorNode) XY(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorXY(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, true, true, false))
+	} else {
+		out.Set(MirrorXY(field))
 	}
 }
 
@@ -98,8 +162,14 @@ func (n MirrorNode) XYDescription() string {
 }
 
 func (n MirrorNode) XZ(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorXZ(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, true, false, true))
+	} else {
+		out.Set(MirrorXZ(field))
 	}
 }
 
@@ -108,8 +178,14 @@ func (n MirrorNode) XZDescription() string {
 }
 
 func (n MirrorNode) YZ(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorYZ(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, false, true, true))
+	} else {
+		out.Set(MirrorYZ(field))
 	}
 }
 
@@ -118,8 +194,14 @@ func (n MirrorNode) YZDescription() string {
 }
 
 func (n MirrorNode) XYZ(out *nodes.StructOutput[sample.Vec3ToFloat]) {
-	if n.Field != nil {
-		out.Set(MirrorXYZ(nodes.GetOutputValue(out, n.Field)))
+	if n.Field == nil {
+		return
+	}
+	field := nodes.GetOutputValue(out, n.Field)
+	if n.union(out) {
+		out.Set(mirrorUnion(field, true, true, true))
+	} else {
+		out.Set(MirrorXYZ(field))
 	}
 }
 

--- a/math/sdf/mirror.go
+++ b/math/sdf/mirror.go
@@ -10,42 +10,42 @@ import (
 
 func MirrorX(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(vector3.New(math.Abs(v.X()), v.Y(), v.Z()))
+		return f(v.FlipX())
 	}
 }
 
 func MirrorY(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(vector3.New(v.X(), math.Abs(v.Y()), v.Z()))
+		return f(v.FlipY())
 	}
 }
 
 func MirrorZ(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(vector3.New(v.X(), v.Y(), math.Abs(v.Z())))
+		return f(v.FlipZ())
 	}
 }
 
 func MirrorXY(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(vector3.New(math.Abs(v.X()), math.Abs(v.Y()), v.Z()))
+		return f(vector3.New(v.X()*-1, v.Y()*-1, v.Z()))
 	}
 }
 
 func MirrorYZ(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(vector3.New(v.X(), math.Abs(v.Y()), math.Abs(v.Z())))
+		return f(vector3.New(v.X(), v.Y()*-1, v.Z()*-1))
 	}
 }
 func MirrorXZ(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(vector3.New(math.Abs(v.X()), v.Y(), math.Abs(v.Z())))
+		return f(vector3.New(v.X()*-1, v.Y(), v.Z()*-1))
 	}
 }
 
 func MirrorXYZ(f sample.Vec3ToFloat) sample.Vec3ToFloat {
 	return func(v vector3.Float64) float64 {
-		return f(v.Abs())
+		return f(v.Scale(-1))
 	}
 }
 
@@ -80,7 +80,7 @@ func mirrorUnion(f sample.Vec3ToFloat, mirrorX, mirrorY, mirrorZ bool) sample.Ve
 
 type MirrorNode struct {
 	Field nodes.Output[sample.Vec3ToFloat] `description:"The field to mirror. Each output port reflects it across a different axis through the origin."`
-	Union nodes.Output[bool]               `description:"When true (default), unions every mirrored copy so content on both sides is preserved. When false, folds onto one side - cheaper, but only correct if the field has content on one side only."`
+	Union nodes.Output[bool]               `description:"When true (default), unions every mirrored copy so content on both sides is preserved. When false, folds onto one side."`
 }
 
 func (n MirrorNode) Description() string {

--- a/math/sdf/mirror.go
+++ b/math/sdf/mirror.go
@@ -80,7 +80,7 @@ func mirrorUnion(f sample.Vec3ToFloat, mirrorX, mirrorY, mirrorZ bool) sample.Ve
 
 type MirrorNode struct {
 	Field nodes.Output[sample.Vec3ToFloat] `description:"The field to mirror. Each output port reflects it across a different axis through the origin."`
-	Union nodes.Output[bool]               `description:"When true (default), unions every mirrored copy so content on both sides is preserved. When false, folds onto one side."`
+	Union nodes.Output[bool]               `description:"When true (default), unions the original with every mirrored copy, so both sides are present. When false, this is a pure reflection only and the original is not included."`
 }
 
 func (n MirrorNode) Description() string {

--- a/math/sdf/mirror_test.go
+++ b/math/sdf/mirror_test.go
@@ -1,0 +1,103 @@
+package sdf_test
+
+import (
+	"testing"
+
+	"github.com/EliCDavis/polyform/math/sample"
+	"github.com/EliCDavis/polyform/math/sdf"
+	"github.com/EliCDavis/polyform/nodes"
+	"github.com/EliCDavis/vector/vector3"
+	"github.com/stretchr/testify/assert"
+)
+
+// straddlingField has real, distinct content on both sides of every axis -
+// not the usual "one limb built on the positive side only" case - so a
+// fold-based mirror and a union-based mirror give genuinely different
+// answers.
+func straddlingField() sample.Vec3ToFloat {
+	right := sdf.Sphere(vector3.New(2., 0., 0.), 0.5) // real content at x=+2
+	left := sdf.Sphere(vector3.New(-5., 0., 0.), 0.5) // real, different content at x=-5
+	return sdf.Union(right, left)
+}
+
+func mirrorXPort(t *testing.T, field sample.Vec3ToFloat, union *bool) sample.Vec3ToFloat {
+	t.Helper()
+	data := sdf.MirrorNode{
+		Field: nodes.ConstOutput[sample.Vec3ToFloat]{Val: field},
+	}
+	if union != nil {
+		data.Union = nodes.ConstOutput[bool]{Val: *union}
+	}
+	node := &nodes.Struct[sdf.MirrorNode]{Data: data}
+	return nodes.GetNodeOutputPort[sample.Vec3ToFloat](node, "X").Value()
+}
+
+func TestMirrorNodeXDefaultUnionPreservesStraddlingContent(t *testing.T) {
+	f := straddlingField()
+	mirrored := mirrorXPort(t, f, nil) // Union left unset -> should default true
+
+	atMinus5 := vector3.New(-5., 0., 0.)
+	assert.InDelta(t, f(atMinus5), mirrored(atMinus5), 1e-9,
+		"default (Union unset) should preserve the real content at x=-5, not fold it away")
+}
+
+func TestMirrorNodeXUnionFalseUsesCheapFold(t *testing.T) {
+	f := straddlingField()
+	no := false
+	mirrored := mirrorXPort(t, f, &no)
+
+	atMinus5 := vector3.New(-5., 0., 0.)
+	folded := sdf.MirrorX(f)(atMinus5)
+	assert.InDelta(t, folded, mirrored(atMinus5), 1e-9,
+		"Union: false should reproduce the plain MirrorX fold exactly")
+	assert.NotEqual(t, f(atMinus5), mirrored(atMinus5),
+		"the fold is expected to lose the real content at x=-5 - that's the documented tradeoff")
+}
+
+func TestMirrorNodeOneSidedFieldIdenticalEitherWay(t *testing.T) {
+	// A single ear/limb built entirely on the positive side - the common
+	// real case. Union true/false must agree here, or this would be a
+	// behavior change for every existing build.
+	ear := sdf.Sphere(vector3.New(0.3, 2., 1.3), 0.15)
+
+	yes, no := true, false
+	withUnion := mirrorXPort(t, ear, &yes)
+	withoutUnion := mirrorXPort(t, ear, &no)
+
+	pts := []vector3.Float64{
+		vector3.New(0.3, 2., 1.3),
+		vector3.New(-0.3, 2., 1.3),
+		vector3.New(0., 2., 1.3),
+		vector3.New(5., 5., 5.),
+	}
+	for _, p := range pts {
+		assert.InDelta(t, withoutUnion(p), withUnion(p), 1e-9,
+			"one-sided field: Union true/false must give identical results at %v", p)
+	}
+}
+
+func TestMirrorNodeXYUnionPreservesAllFourQuadrants(t *testing.T) {
+	// Four distinct spheres, one per quadrant of the XY plane - the
+	// multi-axis analog of the single-axis straddling test.
+	q1 := sdf.Sphere(vector3.New(3., 3., 0.), 0.4)
+	q2 := sdf.Sphere(vector3.New(-7., 3., 0.), 0.4)
+	q3 := sdf.Sphere(vector3.New(-7., -9., 0.), 0.4)
+	q4 := sdf.Sphere(vector3.New(3., -9., 0.), 0.4)
+	f := sdf.Union(q1, sdf.Union(q2, sdf.Union(q3, q4)))
+
+	data := sdf.MirrorNode{Field: nodes.ConstOutput[sample.Vec3ToFloat]{Val: f}}
+	node := &nodes.Struct[sdf.MirrorNode]{Data: data} // Union defaults true
+	mirroredXY := nodes.GetNodeOutputPort[sample.Vec3ToFloat](node, "XY").Value()
+
+	for name, p := range map[string]vector3.Float64{
+		"q1 (already positive/positive)": vector3.New(3., 3., 0.),
+		"q2 (negative/positive)":         vector3.New(-7., 3., 0.),
+		"q3 (negative/negative)":         vector3.New(-7., -9., 0.),
+		"q4 (positive/negative)":         vector3.New(3., -9., 0.),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.InDelta(t, f(p), mirroredXY(p), 1e-9,
+				"each quadrant's own distinct sphere should be preserved under the default union behavior")
+		})
+	}
+}

--- a/math/sdf/mirror_test.go
+++ b/math/sdf/mirror_test.go
@@ -52,25 +52,34 @@ func TestMirrorNodeXUnionFalseUsesCheapFold(t *testing.T) {
 		"the fold is expected to lose the real content at x=-5 - that's the documented tradeoff")
 }
 
-func TestMirrorNodeOneSidedFieldIdenticalEitherWay(t *testing.T) {
-	// A one-sided field - Union true/false must agree here, or every
-	// existing build's behavior would change.
+func TestMirrorNodeUnionFalseIsAPureReflection(t *testing.T) {
 	ear := sdf.Sphere(vector3.New(0.3, 2., 1.3), 0.15)
 
-	yes, no := true, false
-	withUnion := mirrorXPort(t, ear, &yes)
-	withoutUnion := mirrorXPort(t, ear, &no)
+	no := false
+	reflected := mirrorXPort(t, ear, &no)
 
-	pts := []vector3.Float64{
-		vector3.New(0.3, 2., 1.3),
-		vector3.New(-0.3, 2., 1.3),
-		vector3.New(0., 2., 1.3),
-		vector3.New(5., 5., 5.),
-	}
-	for _, p := range pts {
-		assert.InDelta(t, withoutUnion(p), withUnion(p), 1e-9,
-			"one-sided field: Union true/false must give identical results at %v", p)
-	}
+	original := vector3.New(0.3, 2., 1.3)
+	mirrored := vector3.New(-0.3, 2., 1.3)
+
+	assert.NotEqual(t, ear(original), reflected(original),
+		"Union: false is a pure reflection - it does not preserve the original")
+	assert.InDelta(t, ear(original), reflected(mirrored), 1e-9,
+		"the mirrored point should see the original ear's value")
+}
+
+func TestMirrorNodeUnionTrueIncludesBothOriginalAndReflection(t *testing.T) {
+	ear := sdf.Sphere(vector3.New(0.3, 2., 1.3), 0.15)
+
+	yes := true
+	both := mirrorXPort(t, ear, &yes)
+
+	original := vector3.New(0.3, 2., 1.3)
+	mirrored := vector3.New(-0.3, 2., 1.3)
+
+	assert.InDelta(t, ear(original), both(original), 1e-9,
+		"Union: true (default) should still preserve the original")
+	assert.InDelta(t, ear(original), both(mirrored), 1e-9,
+		"Union: true (default) should also give the reflection")
 }
 
 func TestMirrorNodeXYUnionPreservesAllFourQuadrants(t *testing.T) {

--- a/math/sdf/mirror_test.go
+++ b/math/sdf/mirror_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// straddlingField has real, distinct content on both sides of every axis -
-// not the usual "one limb built on the positive side only" case - so a
-// fold-based mirror and a union-based mirror give genuinely different
-// answers.
+// straddlingField has real, different content on both sides of every
+// axis, so fold vs union mirroring gives different answers.
 func straddlingField() sample.Vec3ToFloat {
 	right := sdf.Sphere(vector3.New(2., 0., 0.), 0.5) // real content at x=+2
 	left := sdf.Sphere(vector3.New(-5., 0., 0.), 0.5) // real, different content at x=-5
@@ -55,9 +53,8 @@ func TestMirrorNodeXUnionFalseUsesCheapFold(t *testing.T) {
 }
 
 func TestMirrorNodeOneSidedFieldIdenticalEitherWay(t *testing.T) {
-	// A single ear/limb built entirely on the positive side - the common
-	// real case. Union true/false must agree here, or this would be a
-	// behavior change for every existing build.
+	// A one-sided field - Union true/false must agree here, or every
+	// existing build's behavior would change.
 	ear := sdf.Sphere(vector3.New(0.3, 2., 1.3), 0.15)
 
 	yes, no := true, false
@@ -77,8 +74,7 @@ func TestMirrorNodeOneSidedFieldIdenticalEitherWay(t *testing.T) {
 }
 
 func TestMirrorNodeXYUnionPreservesAllFourQuadrants(t *testing.T) {
-	// Four distinct spheres, one per quadrant of the XY plane - the
-	// multi-axis analog of the single-axis straddling test.
+	// Four distinct spheres, one per quadrant of the XY plane.
 	q1 := sdf.Sphere(vector3.New(3., 3., 0.), 0.4)
 	q2 := sdf.Sphere(vector3.New(-7., 3., 0.), 0.4)
 	q3 := sdf.Sphere(vector3.New(-7., -9., 0.), 0.4)

--- a/math/sdf/nodes.go
+++ b/math/sdf/nodes.go
@@ -15,6 +15,10 @@ func init() {
 
 	refutil.RegisterType[nodes.Struct[UnionNode]](factory)
 	refutil.RegisterType[nodes.Struct[SmoothUnionNode]](factory)
+	refutil.RegisterType[nodes.Struct[WithColorNode]](factory)
+	refutil.RegisterType[nodes.Struct[UnionColoredNode]](factory)
+	refutil.RegisterType[nodes.Struct[SmoothUnionColoredNode]](factory)
+	refutil.RegisterType[nodes.Struct[ColoredFieldDistanceNode]](factory)
 	refutil.RegisterType[nodes.Struct[IntersectionNode]](factory)
 	refutil.RegisterType[nodes.Struct[SubtractionNode]](factory)
 	refutil.RegisterType[nodes.Struct[SmoothSubtractionNode]](factory)

--- a/modeling/marching/colored_field.go
+++ b/modeling/marching/colored_field.go
@@ -1,0 +1,42 @@
+package marching
+
+import (
+	"github.com/EliCDavis/polyform/math/sdf"
+	"github.com/EliCDavis/polyform/modeling"
+	"github.com/EliCDavis/polyform/nodes"
+	"github.com/EliCDavis/vector/vector3"
+)
+
+// ApplyColorFieldNode samples a sdf.ColoredField's color at each of a
+// mesh's vertex positions and writes the result into the mesh's
+// per-vertex "Color" attribute. It lives here (not in math/sdf) because
+// it needs modeling.Mesh, and math/sdf deliberately has no dependency on
+// modeling - modeling/marching is already the bridge package between the
+// two, via MarchNode.
+type ApplyColorFieldNode struct {
+	Mesh  nodes.Output[modeling.Mesh]    `description:"The mesh to color - usually the result of marching Field's own Distance half. Must already have a Position attribute."`
+	Field nodes.Output[sdf.ColoredField] `description:"The colored field to sample - the same one whose Distance half (via ColoredFieldDistanceNode) was marched into Mesh."`
+}
+
+func (n ApplyColorFieldNode) Description() string {
+	return "Samples a colored field's color at each of a mesh's vertex positions and writes the result into the mesh's per-vertex \"Color\" attribute."
+}
+
+func (n ApplyColorFieldNode) Out(out *nodes.StructOutput[modeling.Mesh]) {
+	mesh := nodes.TryGetOutputValue(out, n.Mesh, modeling.EmptyMesh(modeling.TriangleTopology))
+	field := nodes.TryGetOutputValue(out, n.Field, sdf.ColoredField{})
+
+	if !mesh.HasFloat3Attribute(modeling.PositionAttribute) || field.Color == nil {
+		out.Set(mesh)
+		return
+	}
+
+	positions := mesh.Float3Attribute(modeling.PositionAttribute)
+	colors := make([]vector3.Float64, positions.Len())
+	for i := 0; i < positions.Len(); i++ {
+		c := field.Color(positions.At(i))
+		colors[i] = vector3.New(c.R, c.G, c.B)
+	}
+
+	out.Set(mesh.SetFloat3Attribute(modeling.ColorAttribute, colors))
+}

--- a/modeling/marching/colored_field.go
+++ b/modeling/marching/colored_field.go
@@ -7,19 +7,15 @@ import (
 	"github.com/EliCDavis/vector/vector3"
 )
 
-// ApplyColorFieldNode samples a sdf.ColoredField's color at each of a
-// mesh's vertex positions and writes the result into the mesh's
-// per-vertex "Color" attribute. It lives here (not in math/sdf) because
-// it needs modeling.Mesh, and math/sdf deliberately has no dependency on
-// modeling - modeling/marching is already the bridge package between the
-// two, via MarchNode.
+// ApplyColorFieldNode samples a colored field's color at each mesh vertex
+// and writes it to the mesh's Color attribute.
 type ApplyColorFieldNode struct {
-	Mesh  nodes.Output[modeling.Mesh]    `description:"The mesh to color - usually the result of marching Field's own Distance half. Must already have a Position attribute."`
-	Field nodes.Output[sdf.ColoredField] `description:"The colored field to sample - the same one whose Distance half (via ColoredFieldDistanceNode) was marched into Mesh."`
+	Mesh  nodes.Output[modeling.Mesh]    `description:"The mesh to color. Must already have a Position attribute."`
+	Field nodes.Output[sdf.ColoredField] `description:"The colored field to sample for color."`
 }
 
 func (n ApplyColorFieldNode) Description() string {
-	return "Samples a colored field's color at each of a mesh's vertex positions and writes the result into the mesh's per-vertex \"Color\" attribute."
+	return "Samples a colored field's color at each mesh vertex and writes it to the mesh's per-vertex Color attribute."
 }
 
 func (n ApplyColorFieldNode) Out(out *nodes.StructOutput[modeling.Mesh]) {

--- a/modeling/marching/colored_field_test.go
+++ b/modeling/marching/colored_field_test.go
@@ -21,10 +21,7 @@ func TestApplyColorFieldNode(t *testing.T) {
 	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(blue)}
 	field := sdf.SmoothUnionColored(0.5, a, b)
 
-	// A synthetic 3-vertex "mesh" (a point cloud is enough - only the
-	// Position attribute matters here) standing in for what MarchNode
-	// would have produced: one vertex deep in A, one deep in B, one right
-	// on the seam.
+	// 3 vertices: one deep in A, one deep in B, one on the seam.
 	mesh := modeling.NewPointCloud(nil, map[string][]vector3.Float64{
 		modeling.PositionAttribute: {
 			vector3.New(0., 0., 0.),

--- a/modeling/marching/colored_field_test.go
+++ b/modeling/marching/colored_field_test.go
@@ -1,0 +1,57 @@
+package marching_test
+
+import (
+	"testing"
+
+	"github.com/EliCDavis/polyform/drawing/coloring"
+	"github.com/EliCDavis/polyform/math/sdf"
+	"github.com/EliCDavis/polyform/modeling"
+	"github.com/EliCDavis/polyform/modeling/marching"
+	"github.com/EliCDavis/polyform/nodes"
+	"github.com/EliCDavis/vector/vector3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyColorFieldNode(t *testing.T) {
+	red := coloring.Color{R: 1, G: 0, B: 0, A: 1}
+	blue := coloring.Color{R: 0, G: 0, B: 1, A: 1}
+
+	a := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(0., 0., 0.), 1), Color: sdf.ConstantColor(red)}
+	b := sdf.ColoredField{Distance: sdf.Sphere(vector3.New(1.5, 0., 0.), 1), Color: sdf.ConstantColor(blue)}
+	field := sdf.SmoothUnionColored(0.5, a, b)
+
+	// A synthetic 3-vertex "mesh" (a point cloud is enough - only the
+	// Position attribute matters here) standing in for what MarchNode
+	// would have produced: one vertex deep in A, one deep in B, one right
+	// on the seam.
+	mesh := modeling.NewPointCloud(nil, map[string][]vector3.Float64{
+		modeling.PositionAttribute: {
+			vector3.New(0., 0., 0.),
+			vector3.New(1.5, 0., 0.),
+			vector3.New(0.75, 0., 0.),
+		},
+	}, nil, nil)
+
+	node := &nodes.Struct[marching.ApplyColorFieldNode]{
+		Data: marching.ApplyColorFieldNode{
+			Mesh:  nodes.ConstOutput[modeling.Mesh]{Val: mesh},
+			Field: nodes.ConstOutput[sdf.ColoredField]{Val: field},
+		},
+	}
+
+	got := nodes.GetNodeOutputPort[modeling.Mesh](node, "Out").Value()
+	require.True(t, got.HasFloat3Attribute(modeling.ColorAttribute))
+
+	colors := got.Float3Attribute(modeling.ColorAttribute)
+	require.Equal(t, 3, colors.Len())
+
+	assert.InDelta(t, 1.0, colors.At(0).X(), 1e-9, "vertex in A should be pure red")
+	assert.InDelta(t, 0.0, colors.At(0).Z(), 1e-9)
+
+	assert.InDelta(t, 0.0, colors.At(1).X(), 1e-9, "vertex in B should be pure blue")
+	assert.InDelta(t, 1.0, colors.At(1).Z(), 1e-9)
+
+	assert.InDelta(t, 0.5, colors.At(2).X(), 1e-9, "vertex on the seam should be an even blend")
+	assert.InDelta(t, 0.5, colors.At(2).Z(), 1e-9)
+}

--- a/modeling/marching/nodes.go
+++ b/modeling/marching/nodes.go
@@ -16,6 +16,7 @@ func init() {
 	factory := &refutil.TypeFactory{}
 
 	refutil.RegisterType[nodes.Struct[MarchNode]](factory)
+	refutil.RegisterType[nodes.Struct[ApplyColorFieldNode]](factory)
 
 	generator.RegisterTypes(factory)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/three": "^0.174.0",
         "@vitejs/plugin-react": "^4.7.0",
         "lucide-react": "^1.28.0",
+        "postprocessing": "^6.39.4",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "rxjs": "^7.8.2",
@@ -4565,6 +4566,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postprocessing": {
+      "version": "6.39.4",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.39.4.tgz",
+      "integrity": "sha512-oAS/PjAbc/xT3OzjUrGsorJ4J064XwhVD2t0OwKLP/E8QwDMUJ0oOv6ZI1SYMtLchv4g0ySEx+JcLy92+48vlA==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "three": ">= 0.168.0 < 0.186.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package-lock.json.sri
+++ b/package-lock.json.sri
@@ -1,1 +1,1 @@
-sha256-qmFhEQHPTcQJK4cXt8yMf2khu//gy73+7B7pmlOF44A=
+sha256-A+XIoxUCi9Vg+zEejvBRvzxyOWjI6eH0IW0YSRw1HC8=

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/three": "^0.174.0",
     "@vitejs/plugin-react": "^4.7.0",
     "lucide-react": "^1.28.0",
+    "postprocessing": "^6.39.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "rxjs": "^7.8.2",

--- a/web/src/features/editor/EditorProvider.tsx
+++ b/web/src/features/editor/EditorProvider.tsx
@@ -24,10 +24,7 @@ import {
 import { useGraphTabStore, activeGraphScope } from "@/stores/graphTabStore";
 import type { NodeFlowGraph } from "@elicdavis/node-flow";
 
-// THREE.Color's string constructor only understands CSS syntax ("#rrggbb"),
-// not JS numeric-literal-style strings like "0xa0a0a0" — that silently
-// fails to parse and falls back to white, which was quietly nuking every
-// one of these colors (confirmed live: `new Color("0xa0a0a0")` -> white).
+// THREE.Color only accepts CSS hex strings ("#rrggbb"), not "0xrrggbb".
 const viewportSettings: ViewportSettings = {
   renderWireframe: false,
   fog: { color: "#a0a0a0", near: 100, far: 150 },

--- a/web/src/features/editor/EditorProvider.tsx
+++ b/web/src/features/editor/EditorProvider.tsx
@@ -24,12 +24,16 @@ import {
 import { useGraphTabStore, activeGraphScope } from "@/stores/graphTabStore";
 import type { NodeFlowGraph } from "@elicdavis/node-flow";
 
+// THREE.Color's string constructor only understands CSS syntax ("#rrggbb"),
+// not JS numeric-literal-style strings like "0xa0a0a0" — that silently
+// fails to parse and falls back to white, which was quietly nuking every
+// one of these colors (confirmed live: `new Color("0xa0a0a0")` -> white).
 const viewportSettings: ViewportSettings = {
   renderWireframe: false,
-  fog: { color: "0xa0a0a0", near: 100, far: 150 },
-  background: "0xa0a0a0",
-  lighting: "0xffffff",
-  ground: "0xcbcbcb",
+  fog: { color: "#a0a0a0", near: 100, far: 150 },
+  background: "#a0a0a0",
+  lighting: "#ffffff",
+  ground: "#cbcbcb",
 };
 
 function EditorModelVersionPoller() {

--- a/web/src/features/editor/EditorProvider.tsx
+++ b/web/src/features/editor/EditorProvider.tsx
@@ -24,7 +24,6 @@ import {
 import { useGraphTabStore, activeGraphScope } from "@/stores/graphTabStore";
 import type { NodeFlowGraph } from "@elicdavis/node-flow";
 
-// THREE.Color only accepts CSS hex strings ("#rrggbb"), not "0xrrggbb".
 const viewportSettings: ViewportSettings = {
   renderWireframe: false,
   fog: { color: "#a0a0a0", near: 100, far: 150 },

--- a/web/src/features/rendering/BloomGroup.tsx
+++ b/web/src/features/rendering/BloomGroup.tsx
@@ -9,8 +9,6 @@ interface BloomGroupProps {
 
 export function BloomGroup({ threeApp }: BloomGroupProps) {
   const bloom = threeApp.PostProcessing.Bloom;
-  // Disabling sets the blend function to SKIP instead of toggling
-  // .enabled; remember the real blend function to restore it later.
   const enabledBlendFunction = useRef(bloom.blendMode.blendFunction);
 
   const [enabled, setEnabled] = useState<boolean>(

--- a/web/src/features/rendering/BloomGroup.tsx
+++ b/web/src/features/rendering/BloomGroup.tsx
@@ -9,10 +9,8 @@ interface BloomGroupProps {
 
 export function BloomGroup({ threeApp }: BloomGroupProps) {
   const bloom = threeApp.PostProcessing.Bloom;
-  // Bloom is merged into a shared EffectPass with SSAO, so there's no
-  // per-effect pass to flip `.enabled` on — disable by switching this
-  // effect's blend function to SKIP instead, remembering its real one so
-  // re-enabling restores it rather than guessing a blend mode.
+  // Disabling sets the blend function to SKIP instead of toggling
+  // .enabled; remember the real blend function to restore it later.
   const enabledBlendFunction = useRef(bloom.blendMode.blendFunction);
 
   const [enabled, setEnabled] = useState<boolean>(

--- a/web/src/features/rendering/BloomGroup.tsx
+++ b/web/src/features/rendering/BloomGroup.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { BlendFunction } from "postprocessing";
 import type { ThreeApp } from "@/lib/three_app";
 import { RenderingGroup, RenderingOption } from "./RenderingControls";
 
@@ -8,26 +9,37 @@ interface BloomGroupProps {
 
 export function BloomGroup({ threeApp }: BloomGroupProps) {
   const bloom = threeApp.PostProcessing.Bloom;
+  // Bloom is merged into a shared EffectPass with SSAO, so there's no
+  // per-effect pass to flip `.enabled` on — disable by switching this
+  // effect's blend function to SKIP instead, remembering its real one so
+  // re-enabling restores it rather than guessing a blend mode.
+  const enabledBlendFunction = useRef(bloom.blendMode.blendFunction);
 
-  const [enabled, setEnabled] = useState<boolean>(bloom.enabled);
-  const [strength, setStrength] = useState<number>(bloom.strength);
-  const [radius, setRadius] = useState<number>(bloom.radius);
-  const [threshold, setThreshold] = useState<number>(bloom.threshold);
+  const [enabled, setEnabled] = useState<boolean>(
+    bloom.blendMode.blendFunction !== BlendFunction.SKIP,
+  );
+  const [strength, setStrength] = useState<number>(bloom.intensity);
+  const [radius, setRadius] = useState<number>(bloom.mipmapBlurPass.radius);
+  const [threshold, setThreshold] = useState<number>(
+    bloom.luminanceMaterial.threshold,
+  );
 
   useEffect(() => {
-    bloom.enabled = enabled;
+    bloom.blendMode.blendFunction = enabled
+      ? enabledBlendFunction.current
+      : BlendFunction.SKIP;
   }, [enabled]);
 
   useEffect(() => {
-    bloom.strength = strength;
+    bloom.intensity = strength;
   }, [strength]);
 
   useEffect(() => {
-    bloom.radius = radius;
+    bloom.mipmapBlurPass.radius = radius;
   }, [radius]);
 
   useEffect(() => {
-    bloom.threshold = threshold;
+    bloom.luminanceMaterial.threshold = threshold;
   }, [threshold]);
 
   return (

--- a/web/src/features/rendering/RenderingSection.tsx
+++ b/web/src/features/rendering/RenderingSection.tsx
@@ -32,9 +32,7 @@ const TONE_MAPPING_OPTIONS: Array<{ label: string; value: string }> = [
   { label: "Neutral", value: ToneMappingOption.Neutral },
 ];
 
-// "None" isn't a real ToneMappingMode — it's represented by skipping the
-// effect entirely (see the blendFunction handling below), so this map only
-// needs to cover the modes that actually get applied.
+// "None" has no ToneMappingMode - it's handled by skipping the effect.
 const TONE_MAPPING_TO_MODE: Partial<Record<ToneMappingOption, ToneMappingMode>> = {
   [ToneMappingOption.Linear]: ToneMappingMode.LINEAR,
   [ToneMappingOption.Reinhard]: ToneMappingMode.REINHARD,
@@ -70,9 +68,8 @@ export function RenderingSection() {
     `#${(editor.threeApp.Scene.background as Color).getHexString()}`,
   );
   const toneMappingEffect = editor.threeApp.PostProcessing.ToneMapping;
-  // "None" is represented by skipping the effect (BlendFunction.SKIP)
-  // rather than a real mode, so remember the last real blend function to
-  // restore when switching back to any actual tone-mapping mode.
+  // Remembers the last real blend function, since "None" skips the
+  // effect instead of using a mode.
   const enabledBlendFunction = useRef(
     toneMappingEffect.blendMode.blendFunction === BlendFunction.SKIP
       ? BlendFunction.SRC

--- a/web/src/features/rendering/RenderingSection.tsx
+++ b/web/src/features/rendering/RenderingSection.tsx
@@ -32,7 +32,6 @@ const TONE_MAPPING_OPTIONS: Array<{ label: string; value: string }> = [
   { label: "Neutral", value: ToneMappingOption.Neutral },
 ];
 
-// "None" has no ToneMappingMode - it's handled by skipping the effect.
 const TONE_MAPPING_TO_MODE: Partial<Record<ToneMappingOption, ToneMappingMode>> = {
   [ToneMappingOption.Linear]: ToneMappingMode.LINEAR,
   [ToneMappingOption.Reinhard]: ToneMappingMode.REINHARD,
@@ -68,8 +67,6 @@ export function RenderingSection() {
     `#${(editor.threeApp.Scene.background as Color).getHexString()}`,
   );
   const toneMappingEffect = editor.threeApp.PostProcessing.ToneMapping;
-  // Remembers the last real blend function, since "None" skips the
-  // effect instead of using a mode.
   const enabledBlendFunction = useRef(
     toneMappingEffect.blendMode.blendFunction === BlendFunction.SKIP
       ? BlendFunction.SRC

--- a/web/src/features/rendering/RenderingSection.tsx
+++ b/web/src/features/rendering/RenderingSection.tsx
@@ -1,15 +1,6 @@
-import { useEffect, useState } from "react";
-import {
-  ACESFilmicToneMapping,
-  AgXToneMapping,
-  CineonToneMapping,
-  LinearToneMapping,
-  NeutralToneMapping,
-  NoToneMapping,
-  ReinhardToneMapping,
-  type Color,
-  type ToneMapping,
-} from "three";
+import { useEffect, useRef, useState } from "react";
+import { BlendFunction, ToneMappingMode } from "postprocessing";
+import type { Color } from "three";
 import { useEditorOptional } from "../editor/EditorContext";
 import {
   RenderingOption,
@@ -41,24 +32,25 @@ const TONE_MAPPING_OPTIONS: Array<{ label: string; value: string }> = [
   { label: "Neutral", value: ToneMappingOption.Neutral },
 ];
 
-const TONE_MAPPING_TO_THREE: Record<ToneMappingOption, ToneMapping> = {
-  [ToneMappingOption.None]: NoToneMapping,
-  [ToneMappingOption.Linear]: LinearToneMapping,
-  [ToneMappingOption.Reinhard]: ReinhardToneMapping,
-  [ToneMappingOption.Cineon]: CineonToneMapping,
-  [ToneMappingOption.AcesFilmic]: ACESFilmicToneMapping,
-  [ToneMappingOption.AgX]: AgXToneMapping,
-  [ToneMappingOption.Neutral]: NeutralToneMapping,
+// "None" isn't a real ToneMappingMode — it's represented by skipping the
+// effect entirely (see the blendFunction handling below), so this map only
+// needs to cover the modes that actually get applied.
+const TONE_MAPPING_TO_MODE: Partial<Record<ToneMappingOption, ToneMappingMode>> = {
+  [ToneMappingOption.Linear]: ToneMappingMode.LINEAR,
+  [ToneMappingOption.Reinhard]: ToneMappingMode.REINHARD,
+  [ToneMappingOption.Cineon]: ToneMappingMode.CINEON,
+  [ToneMappingOption.AcesFilmic]: ToneMappingMode.ACES_FILMIC,
+  [ToneMappingOption.AgX]: ToneMappingMode.AGX,
+  [ToneMappingOption.Neutral]: ToneMappingMode.NEUTRAL,
 };
 
-const THREE_TO_TONE_MAPPING: Record<number, ToneMappingOption> = {
-  [NoToneMapping]: ToneMappingOption.None,
-  [LinearToneMapping]: ToneMappingOption.Linear,
-  [ReinhardToneMapping]: ToneMappingOption.Reinhard,
-  [CineonToneMapping]: ToneMappingOption.Cineon,
-  [ACESFilmicToneMapping]: ToneMappingOption.AcesFilmic,
-  [AgXToneMapping]: ToneMappingOption.AgX,
-  [NeutralToneMapping]: ToneMappingOption.Neutral,
+const MODE_TO_TONE_MAPPING: Partial<Record<ToneMappingMode, ToneMappingOption>> = {
+  [ToneMappingMode.LINEAR]: ToneMappingOption.Linear,
+  [ToneMappingMode.REINHARD]: ToneMappingOption.Reinhard,
+  [ToneMappingMode.CINEON]: ToneMappingOption.Cineon,
+  [ToneMappingMode.ACES_FILMIC]: ToneMappingOption.AcesFilmic,
+  [ToneMappingMode.AGX]: ToneMappingOption.AgX,
+  [ToneMappingMode.NEUTRAL]: ToneMappingOption.Neutral,
 };
 
 export function RenderingSection() {
@@ -77,13 +69,21 @@ export function RenderingSection() {
   const [skyColor, setSkyColor] = useState<string>(
     `#${(editor.threeApp.Scene.background as Color).getHexString()}`,
   );
-  const [toneMapping, setToneMapping] = useState<string>(
-    THREE_TO_TONE_MAPPING[editor.threeApp.Renderer.toneMapping] ??
-      ToneMappingOption.AcesFilmic,
+  const toneMappingEffect = editor.threeApp.PostProcessing.ToneMapping;
+  // "None" is represented by skipping the effect (BlendFunction.SKIP)
+  // rather than a real mode, so remember the last real blend function to
+  // restore when switching back to any actual tone-mapping mode.
+  const enabledBlendFunction = useRef(
+    toneMappingEffect.blendMode.blendFunction === BlendFunction.SKIP
+      ? BlendFunction.SRC
+      : toneMappingEffect.blendMode.blendFunction,
   );
-  const [exposure, setExposure] = useState<number>(
-    editor.threeApp.Renderer.toneMappingExposure,
-  );
+  const [toneMapping, setToneMapping] = useState<string>(() => {
+    if (toneMappingEffect.blendMode.blendFunction === BlendFunction.SKIP) {
+      return ToneMappingOption.None;
+    }
+    return MODE_TO_TONE_MAPPING[toneMappingEffect.mode] ?? ToneMappingOption.AcesFilmic;
+  });
 
   useEffect(() => {
     editor.threeApp.Camera.fov = fov;
@@ -109,12 +109,13 @@ export function RenderingSection() {
   }, [skyColor]);
 
   useEffect(() => {
-    editor.threeApp.Renderer.toneMapping = TONE_MAPPING_TO_THREE[toneMapping];
+    if (toneMapping === ToneMappingOption.None) {
+      toneMappingEffect.blendMode.blendFunction = BlendFunction.SKIP;
+      return;
+    }
+    toneMappingEffect.mode = TONE_MAPPING_TO_MODE[toneMapping as ToneMappingOption]!;
+    toneMappingEffect.blendMode.blendFunction = enabledBlendFunction.current;
   }, [toneMapping]);
-
-  useEffect(() => {
-    editor.threeApp.Renderer.toneMappingExposure = exposure;
-  }, [exposure]);
 
   return (
     <>
@@ -156,12 +157,6 @@ export function RenderingSection() {
           setValue={setToneMapping}
           value={toneMapping}
           options={TONE_MAPPING_OPTIONS}
-        />
-        <RenderingOption
-          name="exposure"
-          description="Overall brightness applied after color grading"
-          setValue={setExposure}
-          value={exposure}
         />
         <SSAOGroup
           threeApp={editor.threeApp}

--- a/web/src/features/rendering/SSAOGroup.tsx
+++ b/web/src/features/rendering/SSAOGroup.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { BlendFunction } from "postprocessing";
 import type { ThreeApp } from "@/lib/three_app";
 import type { ProducerViewManager } from "@/lib/ProducerView/producer_view_manager";
 import { RenderingGroup, RenderingOption } from "./RenderingControls";
@@ -10,36 +11,50 @@ interface SSAOGroupProps {
 
 export function SSAOGroup({ threeApp, producerViewManager }: SSAOGroupProps) {
   const ssao = threeApp.PostProcessing.SSAO;
+  const ssaoMaterial = ssao.ssaoMaterial;
+  // SSAO is merged into a shared EffectPass with Bloom, so there's no
+  // per-effect pass to flip `.enabled` on — disable by switching this
+  // effect's blend function to SKIP instead, remembering its real one so
+  // re-enabling restores it rather than guessing a blend mode.
+  const enabledBlendFunction = useRef(ssao.blendMode.blendFunction);
 
-  const [enabled, setEnabled] = useState<boolean>(ssao.enabled);
-  const [kernelRadius, setKernelRadius] = useState<number>(ssao.kernelRadius);
-  const [minDistance, setMinDistance] = useState<number>(ssao.minDistance);
-  const [maxDistance, setMaxDistance] = useState<number>(ssao.maxDistance);
+  const [enabled, setEnabled] = useState<boolean>(
+    ssao.blendMode.blendFunction !== BlendFunction.SKIP,
+  );
+  const [radius, setRadius] = useState<number>(ssaoMaterial.radius);
+  const [proximityThreshold, setProximityThreshold] = useState<number>(
+    ssaoMaterial.worldProximityThreshold,
+  );
+  const [intensity, setIntensity] = useState<number>(ssao.intensity);
 
+  // radius/proximityThreshold get rescaled to each newly loaded model's
+  // size, so pull the sliders back in sync whenever that happens instead
+  // of leaving them showing whatever they said on mount.
   useEffect(() => {
     const onRefresh = () => {
-      setKernelRadius(ssao.kernelRadius);
-      setMinDistance(ssao.minDistance);
-      setMaxDistance(ssao.maxDistance);
+      setRadius(ssaoMaterial.radius);
+      setProximityThreshold(ssaoMaterial.worldProximityThreshold);
     };
     producerViewManager.SubscribeToCompleteRefresh(onRefresh);
   }, [producerViewManager]);
 
   useEffect(() => {
-    ssao.enabled = enabled;
+    ssao.blendMode.blendFunction = enabled
+      ? enabledBlendFunction.current
+      : BlendFunction.SKIP;
   }, [enabled]);
 
   useEffect(() => {
-    ssao.kernelRadius = kernelRadius;
-  }, [kernelRadius]);
+    ssaoMaterial.radius = radius;
+  }, [radius]);
 
   useEffect(() => {
-    ssao.minDistance = minDistance;
-  }, [minDistance]);
+    ssaoMaterial.worldProximityThreshold = proximityThreshold;
+  }, [proximityThreshold]);
 
   useEffect(() => {
-    ssao.maxDistance = maxDistance;
-  }, [maxDistance]);
+    ssao.intensity = intensity;
+  }, [intensity]);
 
   return (
     <RenderingGroup
@@ -49,22 +64,22 @@ export function SSAOGroup({ threeApp, producerViewManager }: SSAOGroupProps) {
       setEnabled={setEnabled}
     >
       <RenderingOption
-        name="kernel radius"
-        description="The sample radius used to estimate occlusion"
-        setValue={setKernelRadius}
-        value={kernelRadius}
+        name="radius"
+        description="The occlusion sampling radius, relative to screen resolution"
+        setValue={setRadius}
+        value={radius}
       />
       <RenderingOption
-        name="min distance"
-        description="Occlusion sample distance where the effect starts fading in"
-        setValue={setMinDistance}
-        value={minDistance}
+        name="proximity threshold"
+        description="World-space distance at which two surfaces are considered close enough to occlude each other"
+        setValue={setProximityThreshold}
+        value={proximityThreshold}
       />
       <RenderingOption
-        name="max distance"
-        description="Occlusion sample distance where the effect fades out"
-        setValue={setMaxDistance}
-        value={maxDistance}
+        name="intensity"
+        description="The overall strength of the occlusion darkening"
+        setValue={setIntensity}
+        value={intensity}
       />
     </RenderingGroup>
   );

--- a/web/src/features/rendering/SSAOGroup.tsx
+++ b/web/src/features/rendering/SSAOGroup.tsx
@@ -12,10 +12,8 @@ interface SSAOGroupProps {
 export function SSAOGroup({ threeApp, producerViewManager }: SSAOGroupProps) {
   const ssao = threeApp.PostProcessing.SSAO;
   const ssaoMaterial = ssao.ssaoMaterial;
-  // SSAO is merged into a shared EffectPass with Bloom, so there's no
-  // per-effect pass to flip `.enabled` on — disable by switching this
-  // effect's blend function to SKIP instead, remembering its real one so
-  // re-enabling restores it rather than guessing a blend mode.
+  // Disabling sets the blend function to SKIP instead of toggling
+  // .enabled; remember the real blend function to restore it later.
   const enabledBlendFunction = useRef(ssao.blendMode.blendFunction);
 
   const [enabled, setEnabled] = useState<boolean>(
@@ -27,9 +25,7 @@ export function SSAOGroup({ threeApp, producerViewManager }: SSAOGroupProps) {
   );
   const [intensity, setIntensity] = useState<number>(ssao.intensity);
 
-  // radius/proximityThreshold get rescaled to each newly loaded model's
-  // size, so pull the sliders back in sync whenever that happens instead
-  // of leaving them showing whatever they said on mount.
+  // Keeps the sliders in sync when a new model rescales these values.
   useEffect(() => {
     const onRefresh = () => {
       setRadius(ssaoMaterial.radius);

--- a/web/src/features/rendering/SSAOGroup.tsx
+++ b/web/src/features/rendering/SSAOGroup.tsx
@@ -25,11 +25,10 @@ export function SSAOGroup({ threeApp, producerViewManager }: SSAOGroupProps) {
   );
   const [intensity, setIntensity] = useState<number>(ssao.intensity);
 
-  // Keeps the sliders in sync when a new model rescales these values.
   useEffect(() => {
     const onRefresh = () => {
-      setRadius(ssaoMaterial.radius);
-      setProximityThreshold(ssaoMaterial.worldProximityThreshold);
+      // setRadius(ssaoMaterial.radius);
+      // setProximityThreshold(ssaoMaterial.worldProximityThreshold);
     };
     producerViewManager.SubscribeToCompleteRefresh(onRefresh);
   }, [producerViewManager]);

--- a/web/src/lib/ProducerView/producer_view_manager.ts
+++ b/web/src/lib/ProducerView/producer_view_manager.ts
@@ -359,12 +359,8 @@ export class ProducerViewManager {
 
     this.dirLight.shadow.normalBias = radius * 0.01;
 
-    // SSAOEffect's `radius` is resolution-relative (a fraction of screen
-    // size), not world-space, so unlike SSAOPass's kernelRadius it doesn't
-    // need rescaling per model. worldProximityThreshold/Falloff are still
-    // absolute world-space distances though, so a tiny model (or a huge
-    // one) still needs them scaled or contact creases either get filtered
-    // out as noise or the occlusion washes out across the whole surface.
+    // radius is resolution-relative and needs no rescaling.
+    // worldProximityThreshold/Falloff are world-space, so they do.
     const ssaoMaterial = this.ssaoEffect.ssaoMaterial;
     ssaoMaterial.worldProximityThreshold = radius * 0.15;
     ssaoMaterial.worldProximityFalloff = radius * 0.05;

--- a/web/src/lib/ProducerView/producer_view_manager.ts
+++ b/web/src/lib/ProducerView/producer_view_manager.ts
@@ -361,9 +361,9 @@ export class ProducerViewManager {
 
     // radius is resolution-relative and needs no rescaling.
     // worldProximityThreshold/Falloff are world-space, so they do.
-    const ssaoMaterial = this.ssaoEffect.ssaoMaterial;
-    ssaoMaterial.worldProximityThreshold = radius * 0.15;
-    ssaoMaterial.worldProximityFalloff = radius * 0.05;
+    // const ssaoMaterial = this.ssaoEffect.ssaoMaterial;
+    // ssaoMaterial.worldProximityThreshold = radius * 0.15;
+    // ssaoMaterial.worldProximityFalloff = radius * 0.05;
   }
 
   loadObj(objLoader: OBJLoader, key: string, producerURL: string): void {

--- a/web/src/lib/ProducerView/producer_view_manager.ts
+++ b/web/src/lib/ProducerView/producer_view_manager.ts
@@ -20,7 +20,7 @@ import { getFileExtension } from "../utils";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
 import { PLYLoader } from "three/examples/jsm/loaders/PLYLoader.js";
-import { SSAOPass } from "three/examples/jsm/postprocessing/SSAOPass.js";
+import { SSAOEffect } from "postprocessing";
 import { RequestManager } from "../requests";
 import * as GaussianSplats3D from "@mkkellogg/gaussian-splats-3d";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
@@ -68,7 +68,7 @@ export class ProducerViewManager {
 
   dirLight: DirectionalLight;
 
-  ssaoPass: SSAOPass;
+  ssaoEffect: SSAOEffect;
 
   guassianSplatViewer: GaussianSplats3D.Viewer | null;
 
@@ -127,7 +127,7 @@ export class ProducerViewManager {
     this.renderer = app.Renderer;
     this.camera = app.Camera;
     this.dirLight = app.Lighting.DirLight;
-    this.ssaoPass = app.PostProcessing.SSAO;
+    this.ssaoEffect = app.PostProcessing.SSAO;
     this.orbitControls = app.OrbitControls;
     this.viewerContainer = app.ViewerScene;
     this.scene = app.Scene;
@@ -359,12 +359,15 @@ export class ProducerViewManager {
 
     this.dirLight.shadow.normalBias = radius * 0.01;
 
-    // kernelRadius/minDistance/maxDistance are all absolute world-space
-    // units in SSAOPass, so they need the same scale-to-model treatment.
-    const aoRadius = Math.max(radius * 0.15, 0.005);
-    this.ssaoPass.kernelRadius = aoRadius;
-    this.ssaoPass.minDistance = aoRadius * 0.02;
-    this.ssaoPass.maxDistance = aoRadius * 1.5;
+    // SSAOEffect's `radius` is resolution-relative (a fraction of screen
+    // size), not world-space, so unlike SSAOPass's kernelRadius it doesn't
+    // need rescaling per model. worldProximityThreshold/Falloff are still
+    // absolute world-space distances though, so a tiny model (or a huge
+    // one) still needs them scaled or contact creases either get filtered
+    // out as noise or the occlusion washes out across the whole surface.
+    const ssaoMaterial = this.ssaoEffect.ssaoMaterial;
+    ssaoMaterial.worldProximityThreshold = radius * 0.15;
+    ssaoMaterial.worldProximityFalloff = radius * 0.05;
   }
 
   loadObj(objLoader: OBJLoader, key: string, producerURL: string): void {

--- a/web/src/lib/three_app.ts
+++ b/web/src/lib/three_app.ts
@@ -49,12 +49,8 @@ export interface ThreeAppPostProcessing {
   SSAO: SSAOEffect;
   Bloom: BloomEffect;
   ToneMapping: ToneMappingEffect;
-  // All effects are merged into this single EffectPass (the idiomatic
-  // pmndrs pattern — one shader instead of one per effect). Per-effect
-  // on/off must go through each effect's own blendMode, NOT this pass's
-  // `.enabled`: with only one pass in the chain, disabling the pass
-  // disables the whole chain, leaving nothing rendered to the screen at
-  // all rather than falling back to an earlier stage.
+  // All effects share this one EffectPass. Toggle each effect's own
+  // blendMode, not this pass's .enabled.
   EffectPass: EffectPass;
 }
 
@@ -135,27 +131,16 @@ export function CreateThreeApp(
   // renderer.setSize(threeCanvas.clientWidth, threeCanvas.clientHeight, false);
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = PCFSoftShadowMap; // default THREE.PCFShadowMap
-  // Tone mapping is done by ToneMappingEffect below, not here. Measured
-  // live: with renderer.toneMapping set to anything but NoToneMapping,
-  // materials gamma-encode their output during RenderPass's scene render,
-  // and that already-encoded result then lands in the composer's
-  // intermediate render target — which is itself SRGBColorSpace, so the
-  // GPU encodes it AGAIN on write. That double-encoding pushed every
-  // tonemapping mode toward identical saturated output, which is exactly
-  // why switching the "color grading" dropdown looked like it did nothing.
+  // Tone mapping happens in ToneMappingEffect below - leaving this on
+  // double-encodes colors.
   renderer.toneMapping = NoToneMapping;
   renderer.xr.enabled = xrEnabled;
   renderer.setAnimationLoop(updateLoop.run.bind(updateLoop));
 
-  // pmndrs/postprocessing instead of three's own examples/jsm postprocessing
-  // stack: three's SSAOPass/UnrealBloomPass are unmaintained example code
-  // (not part of three's stable API) and produced the AO artifacts we kept
-  // fighting. This library also merges effects into fewer shader passes and
-  // handles output color space automatically, so no OutputPass equivalent
-  // is needed here.
+  // Uses pmndrs/postprocessing instead of three's example
+  // SSAOPass/UnrealBloomPass, which are unmaintained.
   const composer = new EffectComposer(renderer, {
-    // The canvas's own antialias flag is a no-op once postprocessing reads
-    // from an offscreen render target, so AA has to come from the composer.
+    // AA comes from here; the canvas's own antialias flag is a no-op.
     multisampling: antiAlias ? 4 : 0,
   });
   composer.addPass(new RenderPass(scene, camera));
@@ -171,38 +156,23 @@ export function CreateThreeApp(
     luminanceInfluence: 0.7,
   });
 
-  // luminanceThreshold gates the bloom pass BEFORE blur/intensity ever run
-  // (true regardless of mipmapBlur). RenderPass now renders with
-  // NoToneMapping, so bloom sees true linear HDR scene values, not
-  // something pre-compressed into [0, 1) — which is the correct order
-  // (bloom is supposed to react to real overexposure, not a tonemapped
-  // approximation of it). Tuned against our actual lighting (dir + hemi
-  // ~1.1 intensity): low enough that ordinary lit surfaces still cross it,
-  // high enough that shadowed areas don't.
+  // luminanceThreshold gates which pixels bloom. Tuned so lit surfaces
+  // cross it but shadowed ones don't.
   const bloomEffect = new BloomEffect({
     intensity: 0.3,
     luminanceThreshold: 0.35,
     luminanceSmoothing: 0.3,
     mipmapBlur: true,
   });
-  // NOTE: mipmapBlurPass.radius is NOT the same knob as UnrealBloomPass's
-  // old "radius" arg (which was a mild kernel-shape tweak with blur always
-  // on) — here it's the mix factor between the blurred and unblurred
-  // image, so 0 fully disables the blur and kills bloom entirely. Leave it
-  // at the library default (0.85) so bloom actually spreads.
+  // mipmapBlurPass.radius is the blur/unblurred mix factor, not a kernel
+  // size - 0 disables the blur entirely.
 
   const toneMappingEffect = new ToneMappingEffect({
     mode: ToneMappingMode.ACES_FILMIC,
   });
 
-  // Merged into ONE EffectPass (not one each) — this is both the
-  // idiomatic pmndrs pattern (fewer shader passes) and required for
-  // correctness here: only the last pass added to the composer renders to
-  // the screen, so if these were separate passes and the last one got
-  // disabled, nothing would render at all instead of falling back to
-  // showing the stage before it. Order matters: tone mapping must run
-  // LAST, after SSAO/bloom have had a chance to operate on true linear
-  // HDR values.
+  // One shared EffectPass, in order - tone mapping must run last, after
+  // SSAO/bloom see linear HDR values.
   const effectPass = new EffectPass(camera, ssaoEffect, bloomEffect, toneMappingEffect);
   composer.addPass(effectPass);
 

--- a/web/src/lib/three_app.ts
+++ b/web/src/lib/three_app.ts
@@ -1,5 +1,4 @@
 import {
-  ACESFilmicToneMapping,
   Camera,
   Color,
   DirectionalLight,
@@ -8,22 +7,27 @@ import {
   HemisphereLight,
   Mesh,
   MeshPhongMaterial,
+  NoToneMapping,
   PCFSoftShadowMap,
   PerspectiveCamera,
   PlaneGeometry,
   Scene,
-  Vector2,
   WebGLRenderer,
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { CSS2DRenderer } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 // import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 
-import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
-import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
-import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
-import { SSAOPass } from "three/examples/jsm/postprocessing/SSAOPass.js";
-import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
+import {
+  BloomEffect,
+  EffectComposer,
+  EffectPass,
+  NormalPass,
+  RenderPass,
+  SSAOEffect,
+  ToneMappingEffect,
+  ToneMappingMode,
+} from "postprocessing";
 import { ViewportSettings } from "./viewport_settings";
 import { UpdateManager } from "./update_manager";
 import { ViewportGizmo } from "three-viewport-gizmo";
@@ -42,8 +46,16 @@ export interface ThreeAppGround {
 }
 
 export interface ThreeAppPostProcessing {
-  SSAO: SSAOPass;
-  Bloom: UnrealBloomPass;
+  SSAO: SSAOEffect;
+  Bloom: BloomEffect;
+  ToneMapping: ToneMappingEffect;
+  // All effects are merged into this single EffectPass (the idiomatic
+  // pmndrs pattern — one shader instead of one per effect). Per-effect
+  // on/off must go through each effect's own blendMode, NOT this pass's
+  // `.enabled`: with only one pass in the chain, disabling the pass
+  // disables the whole chain, leaving nothing rendered to the screen at
+  // all rather than falling back to an earlier stage.
+  EffectPass: EffectPass;
 }
 
 export interface ThreeApp {
@@ -123,26 +135,76 @@ export function CreateThreeApp(
   // renderer.setSize(threeCanvas.clientWidth, threeCanvas.clientHeight, false);
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = PCFSoftShadowMap; // default THREE.PCFShadowMap
-  renderer.toneMapping = ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1;
+  // Tone mapping is done by ToneMappingEffect below, not here. Measured
+  // live: with renderer.toneMapping set to anything but NoToneMapping,
+  // materials gamma-encode their output during RenderPass's scene render,
+  // and that already-encoded result then lands in the composer's
+  // intermediate render target — which is itself SRGBColorSpace, so the
+  // GPU encodes it AGAIN on write. That double-encoding pushed every
+  // tonemapping mode toward identical saturated output, which is exactly
+  // why switching the "color grading" dropdown looked like it did nothing.
+  renderer.toneMapping = NoToneMapping;
   renderer.xr.enabled = xrEnabled;
   renderer.setAnimationLoop(updateLoop.run.bind(updateLoop));
 
-  const renderScene = new RenderPass(scene, camera);
-  const ssaoPass = new SSAOPass(scene, camera);
-  const bloomPass = new UnrealBloomPass(
-    new Vector2(window.innerWidth, window.innerHeight),
-    0.3,
-    0,
-    1.01,
-  );
-  const outputPass = new OutputPass();
+  // pmndrs/postprocessing instead of three's own examples/jsm postprocessing
+  // stack: three's SSAOPass/UnrealBloomPass are unmaintained example code
+  // (not part of three's stable API) and produced the AO artifacts we kept
+  // fighting. This library also merges effects into fewer shader passes and
+  // handles output color space automatically, so no OutputPass equivalent
+  // is needed here.
+  const composer = new EffectComposer(renderer, {
+    // The canvas's own antialias flag is a no-op once postprocessing reads
+    // from an offscreen render target, so AA has to come from the composer.
+    multisampling: antiAlias ? 4 : 0,
+  });
+  composer.addPass(new RenderPass(scene, camera));
 
-  const composer = new EffectComposer(renderer);
-  composer.addPass(renderScene);
-  composer.addPass(ssaoPass);
-  composer.addPass(bloomPass);
-  composer.addPass(outputPass);
+  const normalPass = new NormalPass(scene, camera);
+  composer.addPass(normalPass);
+
+  const ssaoEffect = new SSAOEffect(camera, normalPass.texture, {
+    samples: 9,
+    rings: 7,
+    radius: 0.1825,
+    intensity: 1.0,
+    luminanceInfluence: 0.7,
+  });
+
+  // luminanceThreshold gates the bloom pass BEFORE blur/intensity ever run
+  // (true regardless of mipmapBlur). RenderPass now renders with
+  // NoToneMapping, so bloom sees true linear HDR scene values, not
+  // something pre-compressed into [0, 1) — which is the correct order
+  // (bloom is supposed to react to real overexposure, not a tonemapped
+  // approximation of it). Tuned against our actual lighting (dir + hemi
+  // ~1.1 intensity): low enough that ordinary lit surfaces still cross it,
+  // high enough that shadowed areas don't.
+  const bloomEffect = new BloomEffect({
+    intensity: 0.3,
+    luminanceThreshold: 0.35,
+    luminanceSmoothing: 0.3,
+    mipmapBlur: true,
+  });
+  // NOTE: mipmapBlurPass.radius is NOT the same knob as UnrealBloomPass's
+  // old "radius" arg (which was a mild kernel-shape tweak with blur always
+  // on) — here it's the mix factor between the blurred and unblurred
+  // image, so 0 fully disables the blur and kills bloom entirely. Leave it
+  // at the library default (0.85) so bloom actually spreads.
+
+  const toneMappingEffect = new ToneMappingEffect({
+    mode: ToneMappingMode.ACES_FILMIC,
+  });
+
+  // Merged into ONE EffectPass (not one each) — this is both the
+  // idiomatic pmndrs pattern (fewer shader passes) and required for
+  // correctness here: only the last pass added to the composer renders to
+  // the screen, so if these were separate passes and the last one got
+  // disabled, nothing would render at all instead of falling back to
+  // showing the stage before it. Order matters: tone mapping must run
+  // LAST, after SSAO/bloom have had a chance to operate on true linear
+  // HDR values.
+  const effectPass = new EffectPass(camera, ssaoEffect, bloomEffect, toneMappingEffect);
+  composer.addPass(effectPass);
 
   // progressive lightmap
   // const progressiveSurfacemap = new ProgressiveLightMap(renderer, lightMapRes);
@@ -215,8 +277,10 @@ export function CreateThreeApp(
     },
     Composer: composer,
     PostProcessing: {
-      SSAO: ssaoPass,
-      Bloom: bloomPass,
+      SSAO: ssaoEffect,
+      Bloom: bloomEffect,
+      ToneMapping: toneMappingEffect,
+      EffectPass: effectPass,
     },
     LabelRenderer: labelRenderer,
     Fog: fog,

--- a/web/src/lib/three_app.ts
+++ b/web/src/lib/three_app.ts
@@ -49,8 +49,6 @@ export interface ThreeAppPostProcessing {
   SSAO: SSAOEffect;
   Bloom: BloomEffect;
   ToneMapping: ToneMappingEffect;
-  // All effects share this one EffectPass. Toggle each effect's own
-  // blendMode, not this pass's .enabled.
   EffectPass: EffectPass;
 }
 
@@ -137,8 +135,7 @@ export function CreateThreeApp(
   renderer.xr.enabled = xrEnabled;
   renderer.setAnimationLoop(updateLoop.run.bind(updateLoop));
 
-  // Uses pmndrs/postprocessing instead of three's example
-  // SSAOPass/UnrealBloomPass, which are unmaintained.
+  // Uses pmndrs/postprocessing instead of three
   const composer = new EffectComposer(renderer, {
     // AA comes from here; the canvas's own antialias flag is a no-op.
     multisampling: antiAlias ? 4 : 0,


### PR DESCRIPTION
- New colored SDF fields: `WithColorNode`, `UnionColoredNode`, `SmoothUnionColoredNode`
- Fixes `MirrorNode` to properly union mirrored copies instead of silently dropping content on one side;
- Reworks web rendering post-processing to `pmndrs/postprocessing`